### PR TITLE
fix(tools): Remove temporary recomponents from nuxt demo

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -13,7 +13,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@rebilly/recomponents": "^1.0.0",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/pwa": "^3.0.0-0",
     "nuxt": "^2.0.0"


### PR DESCRIPTION
Remove recomponents from nuxt demo to pass first release via CI