### PR TITLE
Before release

### DIFF
--- a/packages/recomponents/README.md
+++ b/packages/recomponents/README.md
@@ -26,14 +26,14 @@ Or bundled with webpack:
 ```html
 <template>
     <main>
-        <r-loader/>
+        <r-button>Click me</r-button>
     </main>
 </template>
 
 <script>
     import Vue from 'vue'
-    import '@rebilly/recomponents/dist/recomponents.css'
-    import Recomponents from '@rebilly/recomponents'
+    import 'rebilly-recomponents/dist/recomponents.css'
+    import Recomponents from 'rebilly-recomponents'
 
     Vue.use(Recomponents)
 

--- a/packages/recomponents/README.md
+++ b/packages/recomponents/README.md
@@ -18,7 +18,7 @@ Recomponents can be imported directly via CDN:
 ```html
 <script src="https://unpkg.com/vue"></script>
 <script src="https://unpkg.com/@rebilly/recomponents"></script>
-<r-button>Click me</r-template>
+<r-button>Click me</r-button>
 ```
 
 Or bundled with webpack:

--- a/packages/recomponents/src/components/r-badge/r-badge.md
+++ b/packages/recomponents/src/components/r-badge/r-badge.md
@@ -18,18 +18,33 @@ This component has 1 **required** slot that can accept any text:
 
 This component can be used in two modes:
 
-#### UMD module
+#### Webcomponent module
 
 ```html
-<script src="https://unpkg.com/vue"></script>
-<script src="https://unpkg.com/rebilly-recomponents/rebilly-recomponents.umd.min.js"></script>
-
-<rebilly-recomponents-r-badge :type="warning">Badge</rebilly-recomponents-r-badge>
-
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-badge type="warning">Warning</recomponents-r-badge>
+    </body>
+</html>
 ```
 
 #### CommonJS module
 
-```javascript
-// TBD
+```html
+<template>
+    <r-badge type="warning">Warning</r-badge>  
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
 ```

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -5,8 +5,6 @@
 </template>
 
 <script>
-    import './r-badge.scss';
-
     export default {
         name: 'RBadge',
         props: {
@@ -25,3 +23,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-badge.scss';
+</style>

--- a/packages/recomponents/src/components/r-button/r-button.md
+++ b/packages/recomponents/src/components/r-button/r-button.md
@@ -1,3 +1,39 @@
 # Button
 
 Regular button, can be used as action trigger in any part of your application and support all native DOM events for buttons
+
+### Usage
+
+This component can be used in two modes:
+
+#### Webcomponent module
+
+```html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-button>Click me</recomponents-r-button>
+    </body>
+</html>
+
+```
+
+#### CommonJS module
+
+```html
+<template>
+    <r-button>Click me</r-button>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
+```

--- a/packages/recomponents/src/components/r-button/r-button.vue
+++ b/packages/recomponents/src/components/r-button/r-button.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script>
-    import './r-button.scss';
     import RIcon from '../r-icon/r-icon.vue';
 
     export default {
@@ -100,3 +99,7 @@
         methods: {},
     };
 </script>
+
+<style lang="scss">
+    @import './r-button.scss';
+</style>

--- a/packages/recomponents/src/components/r-checkbox/r-checkbox.md
+++ b/packages/recomponents/src/components/r-checkbox/r-checkbox.md
@@ -16,24 +16,34 @@ This component has 1 **optional** slot
 
 This component can be used in two modes:
 
-#### UMD module
+#### Webcomponent module
 
 ```html
-<script src="https://unpkg.com/vue"></script>
-<script src="https://unpkg.com/rebilly-recomponents/rebilly-recomponents.umd.min.js"></script>
-
-<script>
-  let checkboxModel = false;
-</script>
-
-<rebilly-recomponents-r-checkbox
-  caption="Caption"
-  label="Checkbox"
-  v-model="checkboxModel"/>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-checkbox label="Check me"/>
+      />
+    </body>
+</html>
 ```
 
 #### CommonJS module
 
-```javascript
-// TBD
+```html
+<template>
+    <r-checkbox label="Check me"/>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
 ```

--- a/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
+++ b/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-    import './r-checkbox.scss';
     import shortId from 'shortid';
     import RIcon from '../r-icon/r-icon.vue';
 
@@ -124,3 +123,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-checkbox.scss';
+</style>

--- a/packages/recomponents/src/components/r-dropdown/r-dropdown.md
+++ b/packages/recomponents/src/components/r-dropdown/r-dropdown.md
@@ -12,20 +12,56 @@
 | position       | string: `'bottomStart'` , `'bottomEnd'` , `'topStart'` , `'topEnd'` | `'bottomStart'` |
 | slideFrom      | string: `'fade'` , `'top'` , `'bottom'` , `'left'` , `'right'`      | `'fade'`        |
   
-  
+### Usage
+
+This component can be used in two modes:
+
+#### Webcomponent module
+
 ```html
-<template>  
- <r-dropdown :escToHide="escToHide"  
-  :autoHide="autoHide" :globalAutoHide="globalAutoHide" :openOnMount="openOnMount" :disabled="disabled"  
-  :offset="offset" :direction="direction" :position="position" :slideFrom="slideFrom" @input="input"  
-  @setActivePopper="setActivePopper" @toggle="toggle" @toggle-on="toggleOn" @toggle-off="toggleOff">  
- <template #trigger="{popper}">  
- <r-icon-button @click="popper.toggle">  
- <r-icon icon="actions"/>  
- </r-icon-button> </template> <template #content>  
- <div class="popover">  
- <div class="popover-control">  
- <div class="popover-content popover-menu"><a class="popover-menu-item">Edit</a> <a  
-  class="popover-menu-item popover-menu-item-negative">Remove</a></div>  
- </div> </div> </template> </r-dropdown></template>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-dropdown>
+            <div slot="trigger">
+                <recomponents-r-button type="primary">
+                    Click me
+                </recomponents-r-button>
+            </div>
+            <div slot="content">
+                <p>Tile primary content</p>
+            </div>
+        </recomponents-r-dropdown>
+    </body>
+</html>
+
+```
+
+#### CommonJS module
+
+```html
+<template>
+    <r-dropdown>
+        <template #trigger="{popper}">
+            <r-button type="primary" @click="popper.toggle">
+                Click me
+            </r-button>
+        </template>
+        <div slot="content">
+            <p>Tile primary content</p>
+        </div>
+    </r-dropdown>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
 ```

--- a/packages/recomponents/src/components/r-dropdown/r-dropdown.vue
+++ b/packages/recomponents/src/components/r-dropdown/r-dropdown.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script>
-    import './r-dropdown.scss';
     import shortId from 'shortid';
     import '../../directives/r-click-outside';
 
@@ -263,3 +262,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-dropdown.scss';
+</style>

--- a/packages/recomponents/src/components/r-icon-button/r-icon-button.md
+++ b/packages/recomponents/src/components/r-icon-button/r-icon-button.md
@@ -22,3 +22,46 @@ Button with icon, icon is optional.
 | default    | component's content | see the source in `Story` tab |
 | left-icon  | left icon           | see the source in `Story` tab |
 | right-icon | right icon          | see the source in `Story` tab |
+
+### Usage
+
+This component can be used in two modes:
+
+#### Webcomponent module
+
+```html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-icon-button>
+            <recomponents-r-icon slot="left-icon" icon="heart"></recomponents-r-icon>
+            Icon button
+            <recomponents-r-icon slot="right-icon" icon="heart"></recomponents-r-icon>
+        </recomponents-r-icon-button>
+    </body>
+</html>
+```
+
+#### CommonJS module
+
+```html
+<template>
+    <r-icon-button>
+        <r-icon slot="left-icon" icon="heart"></r-icon>
+        Icon button
+        <r-icon slot="right-icon" icon="heart"></r-icon>
+    </r-icon-button>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
+```

--- a/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
+++ b/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script>
-    import '../r-button/r-button.scss';
-    import '../../directives/r-tooltip.scss';
     import '../../directives/r-tooltip';
 
     export default {
@@ -21,6 +19,7 @@
         props: {
             type: {
                 type: String,
+                default: 'default',
                 default: null,
             },
             size: {
@@ -69,3 +68,8 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import '../r-button/r-button.scss';
+    @import '../../directives/r-tooltip.scss';
+</style>

--- a/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
+++ b/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
@@ -20,7 +20,6 @@
             type: {
                 type: String,
                 default: 'default',
-                default: null,
             },
             size: {
                 type: String,

--- a/packages/recomponents/src/components/r-icon/r-icon.md
+++ b/packages/recomponents/src/components/r-icon/r-icon.md
@@ -8,3 +8,39 @@ Icons are a set of SVGs
 |--               | --      | --            |                                                 --|
 | icon            | string  |               | icon name, see the possible values in `Knobs` tab |
 | stopPropagation | boolean | false         |                                                   |
+
+### Usage
+
+This component can be used in two modes:
+
+#### Webcomponent module
+
+```html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-icon icon="heart"/>
+    </body>
+</html>
+
+```
+
+#### CommonJS module
+
+```html
+<template>
+    <r-icon icon="heart"/>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
+```

--- a/packages/recomponents/src/components/r-icon/r-icon.vue
+++ b/packages/recomponents/src/components/r-icon/r-icon.vue
@@ -6,7 +6,6 @@
 </template>
 
 <script>
-    import './r-icon.scss';
     import rIconSprites from './r-icon-sprites.vue';
 
     export default {
@@ -40,3 +39,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-icon.scss';
+</style>

--- a/packages/recomponents/src/components/r-img/r-img.vue
+++ b/packages/recomponents/src/components/r-img/r-img.vue
@@ -66,5 +66,5 @@
 </script>
 
 <style lang="scss">
-
+    @import './r-img.scss'
 </style>

--- a/packages/recomponents/src/components/r-input/r-input.md
+++ b/packages/recomponents/src/components/r-input/r-input.md
@@ -36,3 +36,38 @@ Try to understand these props fast in `Knobs` tab
 ### Events
 
 Possible events are `focus`, `click`, `input`, `keySubmit`, `keyPress`, `keyDown`, watch them in `Actions` tab.  
+
+### Usage
+
+This component can be used in two modes:
+
+#### Webcomponent module
+
+```html
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-input placeholder="Type here" value="Value"/>
+    </body>
+</html>
+```
+
+#### CommonJS module
+
+```html
+<template>
+    <r-input placeholder="Type here" value="Value"/>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
+```

--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -267,7 +267,7 @@
 <style lang="scss">
     @import './r-input.scss';
 
-    textarea {
+    .r-field textarea {
         resize: none;
         overflow-x: hidden;
         overflow-y: auto;

--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -76,7 +76,6 @@
 </template>
 
 <script>
-    import './r-input.scss';
     import shortid from 'shortid';
     import rIcon from '../r-icon/r-icon.vue';
 
@@ -265,7 +264,9 @@
     };
 </script>
 
-<style scoped>
+<style lang="scss">
+    @import './r-input.scss';
+
     textarea {
         resize: none;
         overflow-x: hidden;

--- a/packages/recomponents/src/components/r-loader/__snapshots__/r-loader.spec.js.snap
+++ b/packages/recomponents/src/components/r-loader/__snapshots__/r-loader.spec.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`r-loader.vue renders props.msg when passed 1`] = `
-<div class="r-component r-loader r-loader--loading">
-  <div class="wrapper">
-    <div class="mr-re"></div>
-    <div class="mr-bil"></div>
-    <div class="mr-ly"></div>
-  </div>
-</div>
-`;
-
 exports[`r-loader.vue should not render if show property is false 1`] = ``;
 
 exports[`r-loader.vue should render via SSR and match snapshot 1`] = `

--- a/packages/recomponents/src/components/r-loader/r-loader.md
+++ b/packages/recomponents/src/components/r-loader/r-loader.md
@@ -19,17 +19,33 @@ This component has not slots
 
 This component can be used in two modes
 
-#### UMD module
+#### Webcomponent module
 
 ```html
-<script src="https://unpkg.com/vue"></script>
-<script src="https://unpkg.com/rebilly-recomponents/rebilly-recomponents.umd.min.js"></script>
-
-<rebilly-recomponents-r-loader :show="true"/>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-loader loading="true" show="true"/>            
+    </body>
+</html>
 
 ```
 #### CommonJS module
 
-```javascript
-// TBD
+```html
+<template>
+    <r-loader :loading="true" :show="true"/>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
 ```

--- a/packages/recomponents/src/components/r-loader/r-loader.scss
+++ b/packages/recomponents/src/components/r-loader/r-loader.scss
@@ -1,7 +1,9 @@
 .r-loader {
-    position: absolute;
+    position: fixed;
     z-index: $z-max;
     margin: auto;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     transition: opacity 0.3s ease-out;

--- a/packages/recomponents/src/components/r-loader/r-loader.spec.js
+++ b/packages/recomponents/src/components/r-loader/r-loader.spec.js
@@ -3,16 +3,6 @@ import {renderToString} from '@vue/server-test-utils';
 import RLoader from './r-loader.vue';
 
 describe('r-loader.vue', () => {
-    it('renders props.msg when passed', () => {
-        const wrapper = shallowMount(RLoader, {
-            propsData: {
-                show: true,
-            },
-        });
-
-        expect(wrapper).toMatchSnapshot();
-    });
-
     it('should render via SSR and match snapshot', async () => {
         const wrapper = renderToString(RLoader, {
             propsData: {

--- a/packages/recomponents/src/components/r-loader/r-loader.vue
+++ b/packages/recomponents/src/components/r-loader/r-loader.vue
@@ -9,8 +9,6 @@
 </template>
 
 <script>
-    import './r-loader.scss';
-
     export default {
         name: 'RLoader',
 
@@ -39,3 +37,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-loader.scss';
+</style>

--- a/packages/recomponents/src/components/r-radio/r-radio.vue
+++ b/packages/recomponents/src/components/r-radio/r-radio.vue
@@ -20,7 +20,6 @@
 </template>
 
 <script>
-    import './r-toggle.scss';
     import shortid from 'shortid';
     import rIcon from '../r-icon/r-icon.vue';
 
@@ -88,3 +87,7 @@
         },
     };
 </script>
+
+<style lang="scss">
+    @import './r-toggle.scss';
+</style>

--- a/packages/recomponents/src/components/r-tile/__snapshots__/r-tile.spec.js.snap
+++ b/packages/recomponents/src/components/r-tile/__snapshots__/r-tile.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`r-loader.vue should render Wrapper and match snapshot 1`] = `
+exports[`r-tile.vue should render Wrapper and match snapshot 1`] = `
 <div class="r-component r-tile">
   <!---->
   <!---->
@@ -9,7 +9,7 @@ exports[`r-loader.vue should render Wrapper and match snapshot 1`] = `
 </div>
 `;
 
-exports[`r-loader.vue should render via SSR and match snapshot 1`] = `
+exports[`r-tile.vue should render via SSR and match snapshot 1`] = `
 <div class="r-component r-tile">
   <!---->
   <!---->

--- a/packages/recomponents/src/components/r-tile/r-tile.md
+++ b/packages/recomponents/src/components/r-tile/r-tile.md
@@ -19,25 +19,53 @@ This component has 4 **optional** slots that can be filled with any html markup 
 
 This component can be used in two modes:
 
-#### UMD module
+#### Webcomponent module
 
 ```html
-<script src="https://unpkg.com/vue"></script>
-<script src="https://unpkg.com/rebilly-recomponents/rebilly-recomponents.umd.min.js"></script>
-
-<rebilly-recomponents-r-tile>
-    <template v-slot:title>
-        <h2>Title title</h2>
-    </template>
-    <template v-slot:primary >
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
-    </template>
-</rebilly-recomponents-r-tile>
-
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="./recomponents.js"></script>
+        <link rel="stylesheet" href="./recomponents.css">
+    </head>
+    <body>
+        <recomponents-r-tile>
+            <div slot="title">
+                <h1>Tile title</h1>
+            </div>
+            <div slot="primary">
+                <p>Tile primary content</p>
+            </div>
+            <div slot="secondary">
+                <p>Tile secondary content</p>
+            </div>
+        </recomponents-r-tile>
+    </body>
+</html>
 ```
 
 #### CommonJS module
 
-```javascript
-// TBD
+```html
+<template>
+    <r-tile>
+        <template v-slot:title>
+            <h2>Title title</h2>
+        </template>
+        <template v-slot:primary >
+            <p>Primary content</p>
+        </template>
+        <template v-slot:secondary>
+            <p>Secondary content</p>
+        </template>
+    </r-tile>
+</template>
+<script>
+    import Vue from 'vue'
+    import '@rebilly/recomponents/dist/recomponents.css'
+    import Recomponents from '@rebilly/recomponents'
+
+    Vue.use(Recomponents)
+</script>
 ```

--- a/packages/recomponents/src/components/r-tile/r-tile.spec.js
+++ b/packages/recomponents/src/components/r-tile/r-tile.spec.js
@@ -2,7 +2,7 @@ import {shallowMount} from '@vue/test-utils';
 import {renderToString} from '@vue/server-test-utils';
 import RTile from './r-tile.vue';
 
-describe('r-loader.vue', () => {
+describe('r-tile.vue', () => {
     it('should render Wrapper and match snapshot', () => {
         const wrapper = shallowMount(RTile);
 

--- a/packages/recomponents/src/components/r-tile/r-tile.vue
+++ b/packages/recomponents/src/components/r-tile/r-tile.vue
@@ -16,9 +16,11 @@
 </template>
 
 <script>
-    import './r-tile.scss';
-
     export default {
         name: 'RTile',
     };
 </script>
+
+<style lang="scss">
+    @import './r-tile.scss';
+</style>

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -1,3 +1,4 @@
+import VueI18n from 'vue-i18n';
 import RBadge from './components/r-badge/r-badge.vue';
 import RButton from './components/r-button/r-button.vue';
 import RCheckbox from './components/r-checkbox/r-checkbox.vue';
@@ -28,6 +29,8 @@ const components = {
 };
 
 function install(Vue) {
+    Vue.use(VueI18n);
+
     Object.keys(components).forEach((key) => {
         Vue.component(key, components[key]);
     });

--- a/packages/recomponents/src/stories/payment-form.story.js
+++ b/packages/recomponents/src/stories/payment-form.story.js
@@ -45,11 +45,6 @@ storiesOf('Demo', module)
                             placeholder="Phone"
                         />
                     </p>
-                    <p>
-                        <r-input
-                            placeholder="Credit card"
-                        />
-                    </p>
                 </template>
                 <template v-slot:secondary>
                     <r-checkbox label="Authorize company to charge your payment card, and agree to be bound by the terms of use and privacy policy"/>


### PR DESCRIPTION
### What was a problem?

Lack of styles in umd module version of recomponent + lack of examples for it

### How this PR fixes the problem?

Add entire stylesheet to the page won't help because all content of component it hidden by shadow dom, only styles in SFC will be used. Import of external scss file helps to solve that issue, and that styles will be extracted to separate css file anyway

### Check lists

- [X] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [X] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions
