### PR TITLE
fix(button): Adjust the color, the same with re-ui

### DIFF
--- a/packages/recomponents/src/styles/theme.scss
+++ b/packages/recomponents/src/styles/theme.scss
@@ -256,7 +256,7 @@ body, .article {
 
     // Danger
     --button-danger-color: var(--text-color-light);
-    --button-danger-background: linear-gradient(180deg, var(--negative-color) 0, var(--negative-color-dark));
+    --button-danger-background: linear-gradient(to bottom, #ff201b 0%, var(--negative-color) 100%);
     --button-danger-box-shadow: 0 1px 2px 0 var(--mono-color-200);
     --button-danger-border: none;
     // Danger Hover

--- a/packages/recomponents/src/styles/theme.scss
+++ b/packages/recomponents/src/styles/theme.scss
@@ -67,9 +67,9 @@ body, .article {
     --positive-color: #00AA13;
     --positive-color-light: #C4F7CA;
     --positive-color-dark: #00660B;
-    --negative-color: #E53935;
+    --negative-color: #FF201B;
     --negative-color-light: #FFD4D3;
-    --negative-color-dark: #B5040F;
+    --negative-color-dark: #E53935;
     --warning-color: #F1C400;
     --warning-color-light: #FFF0AD;
     --warning-color-dark: #604E00;
@@ -256,7 +256,7 @@ body, .article {
 
     // Danger
     --button-danger-color: var(--text-color-light);
-    --button-danger-background: linear-gradient(to bottom, #ff201b 0%, var(--negative-color) 100%);
+    --button-danger-background: linear-gradient(180deg, var(--negative-color) 0, var(--negative-color-dark));
     --button-danger-box-shadow: 0 1px 2px 0 var(--mono-color-200);
     --button-danger-border: none;
     // Danger Hover


### PR DESCRIPTION
### What was a problem?

The color of danger button should be the same with re-ui

### How this PR fixes the problem?

~Actually I'm confused why the style is not as the same with re-ui, so I just copied 1 line of the CSS to here. the color is the same but I don't find a var name equals `#ff201b`, how to name it, I still don't know, need your help here @cesarlevel : the most difficult stuff in programming, how to name a var :-)~

Ah fixed it, anyway, have a review.

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

None