### PR TITLE
refactor(r-tabs): rename .tab to .r-tab so that no conflicts in recomm

### DIFF
--- a/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
+++ b/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`r-tabs.vue should render Wrapper and match snapshot 1`] = `
 <div>
-  <ul class="tab"></ul>
-  <div class="tab-content"></div>
+  <ul class="r-tab"></ul>
+  <div class="r-tab-content"></div>
 </div>
 `;
 
 exports[`r-tabs.vue should render via SSR and match snapshot 1`] = `
 <div>
-  <ul class="tab"></ul>
-  <div class="tab-content"></div>
+  <ul class="r-tab"></ul>
+  <div class="r-tab-content"></div>
 </div>
 `;

--- a/packages/recomponents/src/components/r-tabs/r-tabs.scss
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.scss
@@ -1,4 +1,4 @@
-.tab {
+.r-tab {
     flex-grow: 1;
     padding-left: 0;
     list-style: none;
@@ -13,20 +13,20 @@
     border-bottom: 1px solid var(--tab-divided-border-bottom-color);
 }
 
-.tab-divided {
+.r-tab-divided {
     border-bottom: 1px solid var(--tab-divided-border-bottom-color);
 }
 
-.tab-item {
+.r-tab-item {
     display: flex;
     flex: 0 0 auto;
 }
 
-.tab.tab-fluid .tab-item {
+.r-tab.r-tab-fluid .r-tab-item {
     flex: 1 0 auto;
 }
 
-.tab-item .tab-link {
+.r-tab-item .r-tab-link {
     line-height: 1;
     position: relative;
     color: var(--tab-link-color);
@@ -38,42 +38,42 @@
     text-decoration: none;
 }
 
-.tab-item .tab-link:hover {
+.r-tab-item .r-tab-link:hover {
     text-decoration: none;
     color: var(--tab-link-hover-color);
     border-bottom: 3px solid var(--tab-link-hover-border-bottom-color);
 }
 
-.tab-item .tab-link.is-active {
+.r-tab-item .r-tab-link.is-active {
     color: var(--tab-link-active-color);
     border-bottom: 3px solid var(--tab-link-active-border-bottom-color);
 }
 
-.tab-item .tab-link.has-error {
+.r-tab-item .r-tab-link.has-error {
     color: var(--tab-link-error-color);
 }
 
-.tab-item .tab-link.is-active.has-error {
+.r-tab-item .r-tab-link.is-active.has-error {
     border-bottom: 3px solid var(--tab-link-error-border-bottom-color);
 }
 
-.tab-item:first-child .tab-link {
+.r-tab-item:first-child .r-tab-link {
     margin-left: var(--tab-link-first-margin-left);
 }
 
-.tab-content {
+.r-tab-content {
     padding: var(--tab-content-padding);
 }
 
-.tile-content .tab-content {
+.tile-content .r-tab-content {
     padding: var(--tab-content-tile-padding);
 }
 
-.tab-content.tab-content-fitted {
+.r-tab-content.r-tab-content-fitted {
     padding: 0;
 }
 
-.tab-content-item {
+.r-tab-content-item {
     border: 0;
     clip: rect(0 0 0 0);
     height: 1px;
@@ -84,7 +84,7 @@
     width: 1px;
 }
 
-.tab-content-item.is-active {
+.r-tab-content-item.is-active {
     clip: auto;
     height: auto;
     margin: auto;

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -1,22 +1,22 @@
 <template>
     <div>
-        <ul class="tab" :class="[{'tab-divided': divided}, menuClass]">
-            <li v-for="(tab, index) in tabs" class="tab-item">
+        <ul class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]">
+            <li v-for="(tab, index) in tabs" class="r-tab-item">
                 <a v-if="tab.to"
                    :to="tab.to"
-                   class="tab-link"
+                   class="r-tab-link"
                    @click="selectTab(tab, index)"
                    :class="{'is-active': tab.isActive}">
                     {{tab.name}}
                 </a>
-                <a v-else class="tab-link"
+                <a v-else class="r-tab-link"
                    @click="selectTab(tab, index)"
                    :class="{'is-active': tab.isActive}">
                     {{tab.name}}
                 </a>
             </li>
         </ul>
-        <div class="tab-content" :class="contentClass">
+        <div class="r-tab-content" :class="contentClass">
             <slot></slot>
         </div>
     </div>


### PR DESCRIPTION
### What was a problem?

remove the class conflicts in recomm, so renamed .tab to .r-tab

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions