### PR TITLE
Fix badge component

### DIFF
--- a/packages/recomponents/src/components/r-badge/__snapshots__/r-badge.spec.js.snap
+++ b/packages/recomponents/src/components/r-badge/__snapshots__/r-badge.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`r-badge.vue should render Wrapper and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">text <!----></span>`;
+exports[`r-badge.vue should render Wrapper and match snapshot 1`] = `<span class="r-component r-badge r-badge-default">text <!----></span>`;
 
-exports[`r-badge.vue should render via SSR and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">text <!----></span>`;
+exports[`r-badge.vue should render via SSR and match snapshot 1`] = `<span class="r-component r-badge r-badge-default">text <!----></span>`;

--- a/packages/recomponents/src/components/r-badge/__snapshots__/r-badge.spec.js.snap
+++ b/packages/recomponents/src/components/r-badge/__snapshots__/r-badge.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`r-badge.vue should render Wrapper and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">Badge <!----></span>`;
+exports[`r-badge.vue should render Wrapper and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">text <!----></span>`;
 
-exports[`r-badge.vue should render via SSR and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">Badge <!----></span>`;
+exports[`r-badge.vue should render via SSR and match snapshot 1`] = `<span class="r-component r-badge r-badge--type-default">text <!----></span>`;

--- a/packages/recomponents/src/components/r-badge/r-badge.md
+++ b/packages/recomponents/src/components/r-badge/r-badge.md
@@ -4,16 +4,10 @@ Small count and labeling component to highlight any information to a user. Could
 
 ### Props
 
-This component has 
-
-* `type` component's background color, could be `default`, `positive`, `negative`, `warning`, `info`, `tag`
-
-### Slots
-
-This component has 2 slots:
-
-* `text` component's content
-* `actions` to add icon, actions
+| prop     | type    | required | default value | Description                          |
+|--        | --      | --       | --            |                                    --|
+| type     | string  | no       | `'default'`   | Changes background color             |
+| close    | boolean | no       | `false`       | adds a close button to the component |
 
 ### Usage
 

--- a/packages/recomponents/src/components/r-badge/r-badge.scss
+++ b/packages/recomponents/src/components/r-badge/r-badge.scss
@@ -21,32 +21,32 @@
         padding-right: var(--space-xs);
     }
 
-    &--type-default {
+    &.r-badge-default {
         background: var(--badge-default-background);
         border: var(--badge-default-border);
     }
 
-    &--type-positive {
+    &.r-badge-positive {
         background: var(--badge-positive-background);
         border: var(--badge-positive-border);
     }
 
-    &--type-negative {
+    &.r-badge-negative {
         background: var(--badge-negative-background);
         border: var(--badge-negative-border);
     }
 
-    &--type-warning {
+    &.r-badge-warning {
         background: var(--badge-warning-background);
         border: var(--badge-warning-border);
     }
 
-    &--type-info {
+    &.r-badge-info {
         background: var(--badge-info-background);
         border: var(--badge-info-border);
     }
 
-    &--type-tag {
+    &.r-badge-tag {
         background: var(--badge-tag-background);
         color: var(--badge-tag-color);
         border-radius: var(--badge-tag-border-radius);
@@ -56,7 +56,7 @@
         text-overflow: ellipsis;
     }
 
-    &--type-tag-secondary {
+    &.r-badge-tag-secondary {
         background: var(--badge-tag-secondary-background);
         color: var(--badge-tag-secondary-color);
         border-radius: var(--badge-tag-secondary-border-radius);

--- a/packages/recomponents/src/components/r-badge/r-badge.scss
+++ b/packages/recomponents/src/components/r-badge/r-badge.scss
@@ -17,6 +17,10 @@
     white-space: nowrap;
     box-shadow: 0 0 0 2px #FFFFFF;
 
+    &.has-icon-close {
+        padding-right: var(--space-xs);
+    }
+
     &--type-default {
         background: var(--badge-default-background);
         border: var(--badge-default-border);
@@ -52,39 +56,19 @@
         text-overflow: ellipsis;
     }
 
-    &--icon-close {
+    &--type-tag-secondary {
+        background: var(--badge-tag-secondary-background);
+        color: var(--badge-tag-secondary-color);
+        border-radius: var(--badge-tag-secondary-border-radius);
+        box-shadow: var(--badge-tag-secondary-box-shadow);
+        white-space: nowrap;
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+    }
+
+    & .r-badge-icon {
         cursor: pointer;
-        right: 0;
-        top: 0;
-        bottom: 0;
-        font-weight: var(--badge-tag-font-weight);
-        font-style: normal;
-        transition: var(--badge-tag-icon-transition);
-        margin-left: var(--badge-tag-icon-margin-left);
-        position: relative;
-        line-height: var(--badge-font-line-height);
-        display: block;
-        float: right;
-        text-align: center;
-        width: 16px;
-        border-radius: var(--badge-tag-icon-border-radius);
-
-        &:after {
-            content: '×';
-            color: var(--badge-icon-color);
-            font-size: 14px;
-        }
-
-        &:focus,
-        &:hover {
-            background: none;
-            color: var(--badge-tag-color);
-        }
-
-        &:focus:after,
-        &:hover:after {
-            color: var(--badge-tag-color);
-        }
-
+        fill: var(--gray-color-dark);
     }
 }

--- a/packages/recomponents/src/components/r-badge/r-badge.spec.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.spec.js
@@ -32,6 +32,7 @@ describe('r-badge.vue', () => {
         expect(type.validator('warning')).toBeTruthy();
         expect(type.validator('info')).toBeTruthy();
         expect(type.validator('tag')).toBeTruthy();
+        expect(type.validator('tag-secondary')).toBeTruthy();
         expect(type.validator('impossible')).toBeFalsy();
     });
 
@@ -45,6 +46,6 @@ describe('r-badge.vue', () => {
             },
         });
 
-        expect(wrapper.classes()).toContain('r-badge--type-warning');
+        expect(wrapper.classes()).toContain('r-badge-warning');
     });
 });

--- a/packages/recomponents/src/components/r-badge/r-badge.spec.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.spec.js
@@ -6,7 +6,7 @@ describe('r-badge.vue', () => {
     it('should render Wrapper and match snapshot', async () => {
         const wrapper = mount(RBadge, {
             slots: {
-                default: '<strong>default message</strong>',
+                default: 'text',
             },
         });
 
@@ -16,7 +16,7 @@ describe('r-badge.vue', () => {
     it('should render via SSR and match snapshot', async () => {
         const wrapper = renderToString(RBadge, {
             slots: {
-                default: '<strong>default message</strong>',
+                default: 'text',
             },
         });
 

--- a/packages/recomponents/src/components/r-badge/r-badge.story.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.story.js
@@ -1,11 +1,14 @@
 import {storiesOf} from '@storybook/vue';
-import {text, select} from '@storybook/addon-knobs';
+import {text, select, boolean} from '@storybook/addon-knobs';
 import markdown from './r-badge.md';
+import {action} from '@storybook/addon-actions';
 
 storiesOf('Components', module)
     .add('Badge', () => ({
         template: `
             <r-badge
+                :close="close"
+                @close="closeBadge"
                 :type="type">
                 {{text}}
             </r-badge>
@@ -19,12 +22,19 @@ storiesOf('Components', module)
                     'warning',
                     'info',
                     'tag',
+                    'tag-secondary',
                 ]),
             },
             text: {
                 default: text('Text', 'Click me'),
             },
+            close: {
+                default: boolean('Close', false),
+            }
         },
+        methods: {
+            closeBadge: action('close'),
+        }
     }), {
         notes: {markdown},
     });

--- a/packages/recomponents/src/components/r-badge/r-badge.story.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.story.js
@@ -26,7 +26,7 @@ storiesOf('Components', module)
                 ]),
             },
             text: {
-                default: text('Text', 'Click me'),
+                default: text('Text', 'Badge'),
             },
             close: {
                 default: boolean('Close', false),

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -1,21 +1,23 @@
 <template>
     <span class="r-component r-badge" :class="classes">
-        <slot name="text">Badge</slot>
-        <slot name="actions">
-            <template v-if="type === 'tag'">
-                <i aria-hidden="true"
-                   tabindex="1"
-                   @keypress.enter.prevent="$emit('close')"
-                   @mousedown.prevent="$emit('close')"
-                   class="r-badge--icon-close"></i>
-            </template>
-        </slot>
+        <slot>Badge</slot>
+        <r-icon
+            v-if="close"
+            aria-hidden="true"
+            class="r-icon-gray r-badge-icon"
+            @click="$emit('close')"
+            @keypress.enter.prevent="$emit('close')"
+            @mousedown.prevent="$emit('close')"
+            icon="close-s"/>
     </span>
 </template>
 
 <script>
+    import rIcon from '../r-icon/r-icon.vue';
+
     export default {
         name: 'RBadge',
+        components: {rIcon},
         props: {
             type: {
                 type: String,
@@ -27,12 +29,15 @@
                     'warning',
                     'info',
                     'tag',
+                    'tag-secondary'
                 ].includes(val),
             },
+            close: Boolean,
         },
         computed: {
             classes() {
                 return {
+                    'has-icon-close': !!this.close,
                     [`r-badge--type-${this.type}`]: !!this.type,
                 };
             },

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -32,13 +32,16 @@
                     'tag-secondary'
                 ].includes(val),
             },
-            close: Boolean,
+            close: {
+                type: Boolean,
+                default: false,
+            },
         },
         computed: {
             classes() {
                 return {
                     'has-icon-close': !!this.close,
-                    [`r-badge--type-${this.type}`]: !!this.type,
+                    [`r-badge-${this.type}`]: !!this.type,
                 };
             },
         },

--- a/packages/recomponents/src/styles/theme.scss
+++ b/packages/recomponents/src/styles/theme.scss
@@ -92,7 +92,7 @@ body, .article {
     --mono-color-900: #313232;
     --mono-color-1000: #000000;
 
-    --text-color: var(--secondary-color);
+    --text-color: #0D2B3E;
     --text-color-light: var(--mono-color-0);
     --text-muted: var(--mono-color-800);
 
@@ -188,11 +188,11 @@ body, .article {
     --badge-tag-background: var(--gray-color-light);
     --badge-tag-color: var(--mono-color-700);
     --badge-tag-border-radius: var(--border-radius-xxs);
-    --badge-icon-color: var(--mono-color-800);
     --badge-tag-font-weight: var(--font-weight-bold);
-    --badge-tag-icon-transition: all var(--timing-100) var(--animation-ease);
-    --badge-tag-icon-margin-left: var(--space-xs);
-    --badge-tag-icon-border-radius: none;
+    --badge-tag-secondary-background: var(--mono-color-0);
+    --badge-tag-secondary-color: var(--mono-color-700);
+    --badge-tag-secondary-border-radius: var(--border-radius-xxs);
+    --badge-tag-secondary-box-shadow: 0 0 0 1px var(--gray-color);
 
     // Buttons
     // ------------------------------------------------


### PR DESCRIPTION
### What was a problem?

- RBadge had a slot for text that was really unnecessary. To setup the component and put some text you would need to define the slot:

`<r-badge><span slot="text">Some text<span></r-badge>`
 
now we can just do `<r-badge>Some text</r-badge>`

### How this PR fixes the problem?

- Eliminated the `actions` and `text` slot. 
- Added a new prop call `close` to add a close icon
- Updated the UI for the component
- Changed the CSS to use SMACSS
- Updated tests

### Check lists

- [x] Readme file updated with actual description and example
- [x] Added all ARIA attributes required for component
- [x] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions