### PR TITLE
fix(r-input): update r-input as it's updated in recomm again

### DIFF
--- a/packages/recomponents/src/components/r-input/r-input.md
+++ b/packages/recomponents/src/components/r-input/r-input.md
@@ -22,8 +22,10 @@ Try to understand these props fast in `Knobs` tab
 | submitOnEnter         | boolean | false         |
 | leftIcon              | string  |               |
 | leftIconClickPointer  | boolean | false         |
+| leftIconSpinning      | boolean | false         |
 | rightIcon             | string  |               |
 | rightIconClickPointer | boolean | false         |
+| rightIconSpinning     | boolean | false         |
 | leftLabel             | string  |               |
 | rightLabel            | string  |               |
 | password              | string  |               |

--- a/packages/recomponents/src/components/r-input/r-input.scss
+++ b/packages/recomponents/src/components/r-input/r-input.scss
@@ -38,8 +38,7 @@
     outline: none;
 
     &:focus {
-        box-shadow: var(--input-focus-box-shadow);
-        border: var(--input-focus-border);
+        box-shadow: inset 0 0 0 2px var(--primary-color);
     }
 }
 

--- a/packages/recomponents/src/components/r-input/r-input.story.js
+++ b/packages/recomponents/src/components/r-input/r-input.story.js
@@ -16,8 +16,10 @@ storiesOf('Components', module)
                 :submitOnEnter="submitOnEnter"
                 :leftIcon="leftIcon"
                 :leftIconClickPointer="leftIconClickPointer"
+                :leftIconSpinning="leftIconSpinning"
                 :rightIcon="rightIcon"
                 :rightIconClickPointer="rightIconClickPointer"
+                :rightIconSpinning="rightIconSpinning"
                 :leftLabel="leftLabel"
                 :rightLabel="rightLabel"
                 :password="password"
@@ -69,11 +71,17 @@ storiesOf('Components', module)
             leftIconClickPointer: {
                 default: boolean('leftIconClickPointer', false),
             },
+            leftIconSpinning: {
+                default: boolean('leftIconSpinning', false),
+            },
             rightIcon: {
                 default: select('rightIcon', ['', 'search', 'customers', 'lock', 'burger'], ''),
             },
             rightIconClickPointer: {
                 default: boolean('rightIconClickPointer', false),
+            },
+            rightIconSpinning: {
+                default: boolean('rightIconSpinning', false),
             },
             leftLabel: {
                 default: select('leftLabel', ['', 'left label'], ''),

--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -16,6 +16,7 @@
                 @keyup="keyPress"
                 @keydown="keyDown"
                 @focus="focus"
+                @blur="blur"
                 @click="click"
                 :name="name"
                 :maxlength="maxLength"
@@ -56,7 +57,7 @@
         <div class="r-field-group" v-if="isGroupedInput">
             <div class="r-field-addon no-flex text-muted" v-if="leftLabel">{{leftLabel}}</div>
             <div class="r-field-control" :class="fieldStyles">
-                <r-icon :icon="leftIcon" v-if="leftIcon" :class="{'cursor-pointer': leftIconClickPointer}" @click.stop="$emit('left-icon-click')"></r-icon>
+                <r-icon :icon="leftIcon" v-if="leftIcon" :class="{'cursor-pointer': leftIconClickPointer, 'is-spinning': leftIconSpinning}" @click.stop="$emit('left-icon-click')"></r-icon>
                 <input
                     ref="input"
                     class="r-field-input"
@@ -70,11 +71,12 @@
                     @keyup="keyPress"
                     @keydown="keyDown"
                     @focus="focus"
+                    @blur="blur"
                     @click="click"
                     :name="name"
                     :maxlength="maxLength"
                     :autocomplete="autocompleteFlag"/>
-                <r-icon :icon="rightIcon" v-if="rightIcon" :class="{'cursor-pointer': rightIconClickPointer}" @click.stop="$emit('right-icon-click')"></r-icon>
+                <r-icon :icon="rightIcon" v-if="rightIcon" :class="{'cursor-pointer': rightIconClickPointer, 'is-spinning': rightIconSpinning}" @click.stop="$emit('right-icon-click')"></r-icon>
             </div>
             <slot name="right-button"/>
             <div class="r-field-addon no-flex text-muted" v-if="rightLabel">{{rightLabel}}</div>
@@ -137,6 +139,14 @@
                 default: null,
             },
             rightIconClickPointer: {
+                type: Boolean,
+                default: false,
+            },
+            leftIconSpinning: {
+                type: Boolean,
+                default: false,
+            },
+            rightIconSpinning: {
                 type: Boolean,
                 default: false,
             },
@@ -247,6 +257,7 @@
             },
             blur() {
                 (this.$refs.input || this.$refs.textarea).blur();
+                this.$emit('blur');
             },
             focus() {
                 if (this.autoHighlightOnFocus) {


### PR DESCRIPTION
### What was a problem?

v-input is updated in recomm, so I have to update r-input in order to keep the same

### How this PR fixes the problem?

v-input is used in the global search component in recomm, so I need to update r-input.

### Check lists

- [x] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions