### PR TITLE
fix(RBadge): Add default class to RBadge

### DIFF
--- a/packages/recomponents/src/components/r-badge/r-badge.scss
+++ b/packages/recomponents/src/components/r-badge/r-badge.scss
@@ -17,7 +17,7 @@
     white-space: nowrap;
     box-shadow: 0 0 0 2px #FFFFFF;
 
-    &.has-icon-close {
+    &.r-badge-has-icon-close {
         padding-right: var(--space-xs);
     }
 

--- a/packages/recomponents/src/components/r-badge/r-badge.spec.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.spec.js
@@ -36,17 +36,14 @@ describe('r-badge.vue', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should validate all incoming props', () => {
-        const {type} = RBadge.props;
+    it('should render default value if prop is falsy', () => {
+        const wrapper = mount(RBadge, {
+            props: {
+                type: false,
+            },
+        });
 
-        expect(type.validator('default')).toBeTruthy();
-        expect(type.validator('positive')).toBeTruthy();
-        expect(type.validator('negative')).toBeTruthy();
-        expect(type.validator('warning')).toBeTruthy();
-        expect(type.validator('info')).toBeTruthy();
-        expect(type.validator('tag')).toBeTruthy();
-        expect(type.validator('tag-secondary')).toBeTruthy();
-        expect(type.validator('impossible')).toBeFalsy();
+        expect(wrapper.classes()).toContain('r-badge-default');
     });
 
     it('should render component with type prop', () => {
@@ -69,7 +66,7 @@ describe('r-badge.vue', () => {
             },
         });
 
-        expect(wrapper.classes()).toContain('has-icon-close');
+        expect(wrapper.classes()).toContain('r-badge-has-icon-close');
         expect(wrapper.contains(RIcon)).toBe(true);
     });
 

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -15,7 +15,6 @@
 <script>
     import rIcon from '../r-icon/r-icon.vue';
 
-    // TODO classes prefix has-icon-close
     export default {
         name: 'RBadge',
         components: {rIcon},
@@ -23,15 +22,6 @@
             type: {
                 type: String,
                 default: 'default',
-                validator: val => [
-                    'default',
-                    'positive',
-                    'negative',
-                    'warning',
-                    'info',
-                    'tag',
-                    'tag-secondary',
-                ].includes(val),
             },
             close: {
                 type: Boolean,

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -40,10 +40,15 @@
         },
         computed: {
             classes() {
-                return {
-                    'has-icon-close': !!this.close,
-                    [`r-badge-${this.type}`]: !!this.type,
+                const classes = {
+                    'r-badge-has-icon-close': !!this.close,
                 };
+                if (this.type) {
+                    classes[`r-badge-${this.type}`] = true;
+                } else {
+                    classes['r-badge-default'] = true;
+                }
+                return classes;
             },
         },
     };


### PR DESCRIPTION
### What was a problem?

The default value for the prop `type` wasn't kicking in when passing a falsy value to the prop

### How this PR fixes the problem?

Check if there is a falsy value and if there is it will return `default`
### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions