### PR TITLE
Updating RCheckbox method name and adding comments

### DIFF
--- a/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
+++ b/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
@@ -37,14 +37,14 @@
                 type: String,
                 default: null,
             },
-            selected: { // this is the actual model for the component
+            selected: { // this is the actual parent model for the component
                 type: [Array, String, Number, Boolean],
             },
-            value: {
+            value: { // might be used to decide if checkbox is selected
                 type: [String, Boolean],
                 default: 'on',
             },
-            fuzzy: {
+            fuzzy: { // semi-selected (indeterminate)
                 type: Boolean,
                 default: false,
             },
@@ -69,6 +69,7 @@
                 return false;
             },
             isChecked() {
+                // parent decides if checkbox is indeterminate, which is just visual style - we mark it as always selected
                 if (this.fuzzy) {
                     return true;
                 }
@@ -78,6 +79,7 @@
                 if (Array.isArray(this.selected)) {
                     return this.selected.includes(this.value);
                 }
+                // selected is not empty - compare against value
                 return this.selected === this.value;
             },
             checkIcon() {
@@ -95,10 +97,20 @@
             },
         },
         methods: {
-            getModelValue() {
+            /**
+             * Method used to calculate the modified internal state *after* user action.
+             *
+             * This method is (and must be) used *only* when the checkbox is clicked by the user (@see change).
+             * Checkbox does not keep internal state - it calculates it based on the properties passed.
+             * Therfore on update, it sends the opposite of the current state (as the user has just changed it).
+             * It's up to the parent to update it's model and pass the new value as property, so the checkbox can update itself.
+             */
+            getNegateInternalState() {
                 if (!Array.isArray(this.selected)) {
                     return !this.isChecked;
                 }
+
+                // selected is array -> add/remove value from the array (the opposite of the current state)
 
                 // copy array to prevent mutation on property
                 const copiedModel = this.selected.slice();
@@ -117,7 +129,7 @@
                 // block above to let the `v-model` directive know
                 // the model property is to be mutated in the parent
                 // component
-                this.$emit('input', this.getModelValue());
+                this.$emit('input', this.getNegateInternalState());
             },
         },
     };


### PR DESCRIPTION
Updated method name that's supposed to be used only internally. Surely not fond of the name, but at least it's clear what it does.

Also added a few comments, that I'll later elaborate on in the PR's comments.

### What was a problem?

Misleading method name. Missing information how the component actually works (not that straightforward to follow).

### How this PR fixes the problem?

Provides a basic set of comments, as well as straightforward method name.