### PR TITLE
fix(rtabs): include the value field in the payload of 'tab-select'

### DIFF
--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -59,12 +59,12 @@
             };
         },
         methods: {
-            selectTab({name}, index = null) {
+            selectTab({name, value}, index = null) {
                 this.tabs.forEach((tab, i) => {
                     tab.isActive = (index === i);
                 });
                 if (index !== null) {
-                    this.$emit('tab-selected', {name, index});
+                    this.$emit('tab-selected', {name, value, index});
                 }
             },
             getRouteTab() {


### PR DESCRIPTION
### What was a problem?
RTabs would not work in Recomm because it did not include the `value` field in `tab-selected` event's payload

### How this PR fixes the problem?
This PR add `value` in `tab-selected` event's payload

### Check lists

- N/A [ ] Readme file updated with actual description and example
- N/A [ ] Added all ARIA attributes required for component
- N/A [ ] Added tests for both browser and SSR render and for all components properties
- N/A [ ] Added story with all knobs and actions

### Additional Comments (if any)
Jira Task: [GWY-13960](https://jira.ilabsinc.com/browse/GWY-13960)