### PR TITLE
Make tabs accessible by default

### DIFF
--- a/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
+++ b/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
@@ -3,18 +3,16 @@
 exports[`r-tabs.vue should open current route tab 1`] = `
 <div>
   <div role="tablist" class="r-tab">
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-21" aria-controls="tabpanel-21" class="r-tab-link">
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-custom-id-1" aria-controls="tabpanel-custom-id-1" class="r-tab-link">
         Tab 1
       </button></div>
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-22" aria-controls="tabpanel-22" class="r-tab-link is-active">
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-custom-id-2" aria-controls="tabpanel-custom-id-2" class="r-tab-link is-active">
         Tab 2
       </button></div>
   </div>
   <div class="r-tab-content">
-    <div id="tabpanel-21" role="tabpanel" aria-labelledby="tab-21" style="display: none;">
-      <p>Lorem ipsum</p>
-    </div>
-    <div id="tabpanel-22" role="tabpanel" aria-labelledby="tab-22" style="">
+    <!---->
+    <div id="tabpanel-custom-id-2" role="tabpanel" aria-labelledby="tab-custom-id-2">
       <p>Domus anthem</p>
     </div>
   </div>

--- a/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
+++ b/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
@@ -3,18 +3,18 @@
 exports[`r-tabs.vue should open current route tab 1`] = `
 <div>
   <div role="tablist" class="r-tab">
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-21-control" aria-controls="tab-21" class="r-tab-link">
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-21" aria-controls="tabpanel-21" class="r-tab-link">
         Tab 1
       </button></div>
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-22-control" aria-controls="tab-22" class="r-tab-link is-active">
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-22" aria-controls="tabpanel-22" class="r-tab-link is-active">
         Tab 2
       </button></div>
   </div>
   <div class="r-tab-content">
-    <div id="tab-21" role="tabpanel" aria-labelledby="tab-21-control" style="display: none;">
+    <div id="tabpanel-21" role="tabpanel" aria-labelledby="tab-21" style="display: none;">
       <p>Lorem ipsum</p>
     </div>
-    <div id="tab-22" role="tabpanel" aria-labelledby="tab-22-control" style="">
+    <div id="tabpanel-22" role="tabpanel" aria-labelledby="tab-22" style="">
       <p>Domus anthem</p>
     </div>
   </div>

--- a/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
+++ b/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
@@ -3,18 +3,18 @@
 exports[`r-tabs.vue should open current route tab 1`] = `
 <div>
   <div role="tablist" class="r-tab">
-    <div class="r-tab-item"><a to="[object Object]" role="tab" class="r-tab-link">
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-21-control" aria-controls="tab-21" class="r-tab-link">
         Tab 1
-      </a></div>
-    <div class="r-tab-item"><a to="[object Object]" role="tab" class="r-tab-link is-active">
+      </button></div>
+    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-22-control" aria-controls="tab-22" class="r-tab-link is-active">
         Tab 2
-      </a></div>
+      </button></div>
   </div>
   <div class="r-tab-content">
-    <div style="display: none;">
+    <div id="tab-21" role="tabpanel" aria-labelledby="tab-21-control" style="display: none;">
       <p>Lorem ipsum</p>
     </div>
-    <div style="">
+    <div id="tab-22" role="tabpanel" aria-labelledby="tab-22-control" style="">
       <p>Domus anthem</p>
     </div>
   </div>

--- a/packages/recomponents/src/components/r-tabs/id-helpers.js
+++ b/packages/recomponents/src/components/r-tabs/id-helpers.js
@@ -1,7 +1,0 @@
-export function generateTabId(panelId) {
-    return `tab-${panelId}`;
-}
-
-export function generateTabpanelId(id) {
-    return `tabpanel-${id}`;
-}

--- a/packages/recomponents/src/components/r-tabs/id-helpers.js
+++ b/packages/recomponents/src/components/r-tabs/id-helpers.js
@@ -1,0 +1,7 @@
+export function generateControlId(panelId) {
+  return `${panelId}-control`;
+}
+
+export function generatePanelId(uid) {
+  return `tab-${uid}`;
+}

--- a/packages/recomponents/src/components/r-tabs/id-helpers.js
+++ b/packages/recomponents/src/components/r-tabs/id-helpers.js
@@ -1,7 +1,7 @@
-export function generateControlId(panelId) {
-    return `${panelId}-control`;
+export function generateTabId(panelId) {
+    return `tab-${panelId}`;
 }
 
-export function generatePanelId(uid) {
-    return `tab-${uid}`;
+export function generatePanelId(id) {
+    return `tabpanel-${id}`;
 }

--- a/packages/recomponents/src/components/r-tabs/id-helpers.js
+++ b/packages/recomponents/src/components/r-tabs/id-helpers.js
@@ -2,6 +2,6 @@ export function generateTabId(panelId) {
     return `tab-${panelId}`;
 }
 
-export function generatePanelId(id) {
+export function generateTabpanelId(id) {
     return `tabpanel-${id}`;
 }

--- a/packages/recomponents/src/components/r-tabs/id-helpers.js
+++ b/packages/recomponents/src/components/r-tabs/id-helpers.js
@@ -1,7 +1,7 @@
 export function generateControlId(panelId) {
-  return `${panelId}-control`;
+    return `${panelId}-control`;
 }
 
 export function generatePanelId(uid) {
-  return `tab-${uid}`;
+    return `tab-${uid}`;
 }

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -1,7 +1,7 @@
 <template>
     <div :id="computedPanelId"
          role="tabpanel"
-         :aria-labelledby="computedControlId"
+         :aria-labelledby="computedTabId"
          v-if="$slots.default"
          v-show="isActive"
     >
@@ -11,7 +11,7 @@
 
 <script>
     /* eslint-disable no-underscore-dangle */
-    import {generateControlId, generatePanelId} from './id-helpers';
+    import {generateTabId, generatePanelId} from './id-helpers';
 
     export default {
         name: 'r-tab',
@@ -37,11 +37,14 @@
             };
         },
         computed: {
-            computedPanelId() {
-                return this.panelId || generatePanelId(this._uid);
+            computedAccessibilityId() {
+                return this.panelId || this._uid;
             },
-            computedControlId() {
-                return generateControlId(this.computedPanelId);
+            computedPanelId() {
+                return generatePanelId(this.computedAccessibilityId);
+            },
+            computedTabId() {
+                return generateTabId(this.computedAccessibilityId);
             },
         },
     };

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -1,7 +1,7 @@
 <template>
     <div :id="computedPanelId"
          role="tabpanel"
-         :aria-labelledby="computedPanelId + '-control'"
+         :aria-labelledby="computedControlId"
          v-if="$slots.default"
          v-show="isActive"
     >
@@ -10,6 +10,8 @@
 </template>
 
 <script>
+import { generateControlId, generatePanelId } from './id-helpers';
+
     export default {
         name: 'r-tab',
         props: {
@@ -35,8 +37,11 @@
         },
         computed: {
             computedPanelId() {
-                return this.panelId || `tab-${this._uid}`;
-            }
+                return this.panelId || generatePanelId(this._uid);
+            },
+            computedControlId() {
+                return generateControlId(this.computedPanelId);
+            },
         },
     };
 </script>

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -1,5 +1,10 @@
 <template>
-    <div v-show='isActive'>
+    <div :id="computedPanelId"
+         role="tabpanel"
+         :aria-labelledby="computedPanelId + '-control'"
+         v-if="$slots.default"
+         v-show="isActive"
+    >
         <slot></slot>
     </div>
 </template>
@@ -11,6 +16,7 @@
             name: {
                 required: true,
             },
+            panelId: String,
             value: String,
             active: {
                 type: Boolean,
@@ -26,6 +32,11 @@
             return {
                 isActive: this.active,
             };
+        },
+        computed: {
+            computedPanelId() {
+                return this.panelId || `tab-${this._uid}`;
+            }
         },
     };
 </script>

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -9,6 +9,8 @@
 </template>
 
 <script>
+    import shortId from 'shortid';
+
     export default {
         name: 'r-tab',
         props: {
@@ -34,7 +36,7 @@
         },
         computed: {
             accessibilityId() {
-                return this.panelId || this._uid; /* eslint-disable-line no-underscore-dangle */
+                return this.panelId || shortId.generate();
             },
             tabPanelId() {
                 return `tabpanel-${this.accessibilityId}`;

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -11,7 +11,7 @@
 
 <script>
     /* eslint-disable no-underscore-dangle */
-    import {generateTabId, generatePanelId} from './id-helpers';
+    import {generateTabId, generateTabpanelId} from './id-helpers';
 
     export default {
         name: 'r-tab',
@@ -41,7 +41,7 @@
                 return this.panelId || this._uid;
             },
             computedPanelId() {
-                return generatePanelId(this.computedAccessibilityId);
+                return generateTabpanelId(this.computedAccessibilityId);
             },
             computedTabId() {
                 return generateTabId(this.computedAccessibilityId);

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -10,7 +10,8 @@
 </template>
 
 <script>
-import { generateControlId, generatePanelId } from './id-helpers';
+    /* eslint-disable no-underscore-dangle */
+    import {generateControlId, generatePanelId} from './id-helpers';
 
     export default {
         name: 'r-tab',

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -1,7 +1,7 @@
 <template>
-    <div :id="computedPanelId"
+    <div :id="tabPanelId"
          role="tabpanel"
-         :aria-labelledby="computedTabId"
+         :aria-labelledby="tabId"
          v-if="$slots.default"
          v-show="isActive"
     >
@@ -10,8 +10,6 @@
 </template>
 
 <script>
-    import {generateTabId, generateTabpanelId} from './id-helpers';
-
     export default {
         name: 'r-tab',
         props: {
@@ -36,14 +34,14 @@
             };
         },
         computed: {
-            computedAccessibilityId() {
+            accessibilityId() {
                 return this.panelId || this._uid; /* eslint-disable-line no-underscore-dangle */
             },
-            computedPanelId() {
-                return generateTabpanelId(this.computedAccessibilityId);
+            tabPanelId() {
+                return `tabpanel-${this.accessibilityId}`;
             },
-            computedTabId() {
-                return generateTabId(this.computedAccessibilityId);
+            tabId() {
+                return `tab-${this.accessibilityId}`;
             },
         },
     };

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -2,8 +2,7 @@
     <div :id="tabPanelId"
          role="tabpanel"
          :aria-labelledby="tabId"
-         v-if="$slots.default"
-         v-show="isActive"
+         v-if="$slots.default && isActive"
     >
         <slot></slot>
     </div>

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script>
-    /* eslint-disable no-underscore-dangle */
     import {generateTabId, generateTabpanelId} from './id-helpers';
 
     export default {
@@ -38,7 +37,7 @@
         },
         computed: {
             computedAccessibilityId() {
-                return this.panelId || this._uid;
+                return this.panelId || this._uid; /* eslint-disable-line no-underscore-dangle */
             },
             computedPanelId() {
                 return generateTabpanelId(this.computedAccessibilityId);

--- a/packages/recomponents/src/components/r-tabs/r-tabs.scss
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.scss
@@ -28,6 +28,7 @@
 }
 
 .r-tab-item .r-tab-link {
+    @include reset-button;
     line-height: 1;
     position: relative;
     color: var(--tab-link-color);
@@ -37,25 +38,28 @@
     cursor: pointer;
     transition: var(--tab-link-transition);
     text-decoration: none;
-}
 
-.r-tab-item .r-tab-link:hover {
-    text-decoration: none;
-    color: var(--tab-link-hover-color);
-    border-bottom: 3px solid var(--tab-link-hover-border-bottom-color);
-}
+    &:hover {
+        text-decoration: none;
+        color: var(--tab-link-hover-color);
+    }
 
-.r-tab-item .r-tab-link.is-active {
-    color: var(--tab-link-active-color);
-    border-bottom: 3px solid var(--tab-link-active-border-bottom-color);
-}
+    &:focus {
+        border-bottom: 3px solid var(--tab-link-hover-border-bottom-color);
+    }
 
-.r-tab-item .r-tab-link.has-error {
-    color: var(--tab-link-error-color);
-}
+    &.is-active {
+        color: var(--tab-link-active-color);
+        border-bottom: 3px solid var(--tab-link-active-border-bottom-color);
+    }
 
-.r-tab-item .r-tab-link.is-active.has-error {
-    border-bottom: 3px solid var(--tab-link-error-border-bottom-color);
+    &.has-error {
+        color: var(--tab-link-error-color);
+    }
+
+    &.is-active.has-error {
+        border-bottom: 3px solid var(--tab-link-error-border-bottom-color);
+    }
 }
 
 .r-tab-item:first-child .r-tab-link {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
@@ -137,4 +137,65 @@ describe('r-tabs.vue', () => {
         expect(menuClass.type).toBe(String);
         expect(contentClass.type).toBe(String);
     });
+
+    describe('r-tabs accessibility', () => {
+        it('should set the correct IDs when panelId is provided', () => {
+            const customId1 = 'custom-id-1';
+            const tabA11yId = `tab-${customId1}`;
+            const tabPanelA11yId = `tabpanel-${customId1}`;
+
+            const wrapper = mount(RTabs, {
+                render(h) {
+                    return h(RTabs, {}, [
+                        h(RTab, {
+                            props: {
+                                name: 'Tab 1',
+                                panelId: customId1,
+                            },
+                        }, [
+                            h('p', 'Lorem ipsum'),
+                        ]),
+                    ]);
+                },
+            });
+
+            const tab = wrapper.findAll('.r-tab-link').at(0);
+            const tabPanel = wrapper.find('.r-tab-content > div');
+
+            expect(tab.attributes('id')).toBe(tabA11yId);
+            expect(tab.attributes('aria-controls')).toBe(tabPanelA11yId);
+
+            expect(tabPanel.attributes('id')).toBe(tabPanelA11yId);
+            expect(tabPanel.attributes('aria-labelledby')).toBe(tabA11yId);
+        });
+
+        it('should generate IDs when panelId is not provided', () => {
+            const wrapper = mount(RTabs, {
+                render(h) {
+                    return h(RTabs, {}, [
+                        h(RTab, {
+                            props: {
+                                name: 'Tab 1',
+                            },
+                        }, [
+                            h('p', 'Lorem ipsum'),
+                        ]),
+                    ]);
+                },
+            });
+
+            const tab = wrapper.findAll('.r-tab-link').at(0);
+            const tabPanel = wrapper.find('.r-tab-content > div');
+
+            const generatedShortId = tab.attributes('id').replace('tab-', '');
+            const tabA11yId = `tab-${generatedShortId}`;
+            const tabPanelA11yId = `tabpanel-${generatedShortId}`;
+
+            expect(tab.attributes('id')).toBe(tabA11yId);
+            expect(tab.attributes('aria-controls')).toBe(tabPanelA11yId);
+
+            expect(tabPanel.attributes('id')).toBe(tabPanelA11yId);
+            expect(tabPanel.attributes('aria-labelledby')).toBe(tabA11yId);
+        });
+    });
 });

--- a/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
@@ -60,7 +60,7 @@ describe('r-tabs.vue', () => {
         expect(links.at(1).classes().includes('is-active')).toBeTruthy();
     });
 
-    it('should swtich tab on click', async () => {
+    it('should switch tab on click', async () => {
         const wrapper = mount(RTabs, {
             render(h) {
                 return h(RTabs, {}, [

--- a/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
@@ -98,6 +98,7 @@ describe('r-tabs.vue', () => {
                             to: {
                                 fullPath: 'default-route',
                             },
+                            panelId: 'custom-id-1',
                         },
                     }, [
                         h('p', 'Lorem ipsum'),
@@ -108,6 +109,7 @@ describe('r-tabs.vue', () => {
                             to: {
                                 fullPath: 'test-route',
                             },
+                            panelId: 'custom-id-2',
                         },
                     }, [
                         h('p', 'Domus anthem'),

--- a/packages/recomponents/src/components/r-tabs/r-tabs.story.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.story.js
@@ -10,22 +10,13 @@ storiesOf('Components', module)
                 <r-tabs :divided="divided"
                         :menuClass="menuClass"
                         :contentClass="contentClass"
-                        @tab-selected="tabSelected">
-                        <r-tab v-for="(tab, tabIndex) in tabs"
-                        :key="tabIndex"
-                        :name="tab.name">
-                        <r-tile>
-                                <template v-slot:title>
-                                    <h2>{{ tab.name }}</h2>
-                                </template>
-                                <template v-slot:contents>
-                                    <p v-content>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                                        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                                        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-                                        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-                                        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                                </template>
-                            </r-tile>
+                        @tab-selected="tabSelected"
+                >
+                    <r-tab v-for="(tab, tabIndex) in tabs"
+                           :key="tabIndex"
+                           :name="tab.name"
+                    >
+                        {{tab.resource}}
                     </r-tab>
                 </r-tabs>
             </div>
@@ -46,9 +37,9 @@ storiesOf('Components', module)
         },
         data: () => ({
             tabs: [
-                {name: 'Tab 1', resource: ''},
-                {name: 'Tab 2', resource: ''},
-                {name: 'Tab 3', resource: ''},
+                {name: 'Tab 1', resource: 'Tab 1 Content'},
+                {name: 'Tab 2', resource: 'Tab 2 Content'},
+                {name: 'Tab 3', resource: 'Tab 3 Content'},
             ],
         }),
     }), {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -5,8 +5,8 @@
                 <button v-if="tab.to"
                         :to="tab.to"
                         role="tab"
-                        :id="tab.computedTabId"
-                        :aria-controls="tab.computedPanelId"
+                        :id="tab.tabId"
+                        :aria-controls="tab.tabPanelId"
                         class="r-tab-link"
                         @click="selectTab(tab, index)"
                         :class="{'is-active': tab.isActive}"
@@ -16,8 +16,8 @@
                 <button v-else
                         @click="selectTab(tab, index)"
                         role="tab"
-                        :id="tab.computedTabId"
-                        :aria-controls="tab.computedPanelId"
+                        :id="tab.tabId"
+                        :aria-controls="tab.tabPanelId"
                         class="r-tab-link"
                         :class="{'is-active': tab.isActive}"
                 >

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -2,20 +2,27 @@
     <div>
         <div class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]" role="tablist">
             <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
-                <a v-if="tab.to"
-                   :to="tab.to"
-                   role="tab"
-                   class="r-tab-link"
-                   @click="selectTab(tab, index)"
-                   :class="{'is-active': tab.isActive}">
+                <button v-if="tab.to"
+                        :to="tab.to"
+                        role="tab"
+                        :id="tab.computedPanelId + '-control'"
+                        :aria-controls="tab.computedPanelId"
+                        class="r-tab-link"
+                        @click="selectTab(tab, index)"
+                        :class="{'is-active': tab.isActive}"
+                >
                     {{tab.name}}
-                </a>
-                <a v-else class="r-tab-link"
-                   @click="selectTab(tab, index)"
-                   role="tab"
-                   :class="{'is-active': tab.isActive}">
+                </button>
+                <button v-else
+                        @click="selectTab(tab, index)"
+                        role="tab"
+                        :id="tab.computedPanelId + '-control'"
+                        :aria-controls="tab.computedPanelId"
+                        class="r-tab-link"
+                        :class="{'is-active': tab.isActive}"
+                >
                     {{tab.name}}
-                </a>
+                </button>
             </div>
         </div>
         <div class="r-tab-content" :class="contentClass">
@@ -110,6 +117,6 @@
     };
 </script>
 
-<style>
+<style lang="scss">
     @import 'r-tabs.scss';
 </style>

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -5,7 +5,7 @@
                 <button v-if="tab.to"
                         :to="tab.to"
                         role="tab"
-                        :id="tab.computedPanelId + '-control'"
+                        :id="generateControlId(tab.computedPanelId)"
                         :aria-controls="tab.computedPanelId"
                         class="r-tab-link"
                         @click="selectTab(tab, index)"
@@ -16,7 +16,7 @@
                 <button v-else
                         @click="selectTab(tab, index)"
                         role="tab"
-                        :id="tab.computedPanelId + '-control'"
+                        :id="generateControlId(tab.computedPanelId)"
                         :aria-controls="tab.computedPanelId"
                         class="r-tab-link"
                         :class="{'is-active': tab.isActive}"
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+    import { generateControlId } from './id-helpers';
+
     export default {
         name: 'r-tabs',
         props: {
@@ -66,6 +68,7 @@
             };
         },
         methods: {
+            generateControlId,
             selectTab({name, value}, index = null) {
                 this.tabs.forEach((tab, i) => {
                     tab.isActive = (index === i);

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -5,7 +5,7 @@
                 <button v-if="tab.to"
                         :to="tab.to"
                         role="tab"
-                        :id="generateControlId(tab.computedPanelId)"
+                        :id="tab.computedTabId"
                         :aria-controls="tab.computedPanelId"
                         class="r-tab-link"
                         @click="selectTab(tab, index)"
@@ -16,7 +16,7 @@
                 <button v-else
                         @click="selectTab(tab, index)"
                         role="tab"
-                        :id="generateControlId(tab.computedPanelId)"
+                        :id="tab.computedTabId"
                         :aria-controls="tab.computedPanelId"
                         class="r-tab-link"
                         :class="{'is-active': tab.isActive}"
@@ -32,8 +32,6 @@
 </template>
 
 <script>
-    import {generateControlId} from './id-helpers';
-
     export default {
         name: 'r-tabs',
         props: {
@@ -68,7 +66,6 @@
             };
         },
         methods: {
-            generateControlId,
             selectTab({name, value}, index = null) {
                 this.tabs.forEach((tab, i) => {
                     tab.isActive = (index === i);

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script>
-    import { generateControlId } from './id-helpers';
+    import {generateControlId} from './id-helpers';
 
     export default {
         name: 'r-tabs',

--- a/packages/recomponents/src/styles/mixins.scss
+++ b/packages/recomponents/src/styles/mixins.scss
@@ -15,3 +15,30 @@
         }
     }
 }
+
+@mixin reset-button {
+    border: none;
+    margin: 0;
+    padding: 0;
+    width: auto;
+    overflow: visible;
+    font-size: inherit;
+
+    background: transparent;
+
+    /* Normalize `line-height`. Cannot be changed from `normal` in Firefox 4+. */
+    line-height: normal;
+
+    /* Corrects font smoothing for webkit */
+    -webkit-font-smoothing: inherit;
+    -moz-osx-font-smoothing: inherit;
+
+    /* Corrects inability to style clickable `input` types in iOS */
+    -webkit-appearance: none;
+
+    /* Remove excess padding and border in Firefox 4+ */
+    &::-moz-focus-inner {
+        border: 0;
+        padding: 0;
+    }
+}


### PR DESCRIPTION
### What was a problem?

- Tabs had no focus states
- Were not operable via keyboard
- Did not comply with ARIA standards for accessibility

### How this PR fixes the problem?

Tabs should now be accessible out of the box without additional input from the developer.

### Check lists

- [X] Added all ARIA attributes required for component