### PR TITLE
fix(component): Fix icons in IE 11

### DIFF
--- a/packages/recomponents/src/components/r-icon/r-icon.vue
+++ b/packages/recomponents/src/components/r-icon/r-icon.vue
@@ -48,7 +48,7 @@
                 const spritesDiv = document.createElement('div');
                 spritesDiv.style.display = 'none';
                 spritesDiv.innerHTML = RIconSprites;
-                document.body.append(spritesDiv);
+                document.body.appendChild(spritesDiv);
             }
         },
         computed: {


### PR DESCRIPTION
### What was a problem?

![Bug](https://image.prntscr.com/image/shg3Gs0QSBq58uRIpn0nyg.png)

Cannot render any component with icons in IE11

### How this PR fixes the problem?

![Fixed](https://image.prntscr.com/image/bp_qQu-TQneyGTabmvhumA.png)

Changed code to use IE 11 DOM method

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

Component looks unstyled till we will add CSS Vars polyfill, we will do that later.