### PR TITLE
Fix package.json to run script subcommands sequentially

### DIFF
--- a/packages/recomponents/package.json
+++ b/packages/recomponents/package.json
@@ -8,10 +8,10 @@
   "license": "MIT",
   "scripts": {
     "test": "vue-cli-service test:unit",
-    "lint": "npm run lint:js & npm run lint:styles",
+    "lint": "npm run lint:js && npm run lint:styles",
     "lint:js": "vue-cli-service lint",
     "lint:styles": "stylelint **/*.scss",
-    "build": "npm run build:wc & npm run build:lib",
+    "build": "npm run build:wc && npm run build:lib",
     "build:wc": "vue-cli-service build --target wc-async --name recomponents 'src/**/*.vue'",
     "build:lib": "vue-cli-service build --target lib --name recomponents 'src/index.js'",
     "storybook": "start-storybook -p 9001  -s public",

--- a/packages/recomponents/src/components/r-radio/r-radio.spec.js
+++ b/packages/recomponents/src/components/r-radio/r-radio.spec.js
@@ -2,8 +2,6 @@ import {mount, shallowMount} from '@vue/test-utils';
 import {renderToString} from '@vue/server-test-utils';
 import RRadio from './r-radio.vue';
 
-const $t = () => 'custom label';
-
 describe('r-radio.vue', () => {
     it('renders default radio correctly', () => {
         const label = `label-${new Date().getTime()}`;


### PR DESCRIPTION
### What was a problem?
Subcommands in a few `package.json` scripts are being run in two separate processes (first one in a background process and the second one in a standard process)

### How this PR fixes the problem?
Subcommands are now being run sequentially
