### PR TITLE
fix(RInput): Fix undefined exception

### DIFF
--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -254,10 +254,16 @@
                 this.$emit('key-down', event);
             },
             getFocus() {
-                (this.$refs.input || this.$refs.textarea).focus();
+                const e = this.$refs.input || this.$refs.textarea;
+                if (e) {
+                    e.focus();
+                }
             },
             blur() {
-                (this.$refs.input || this.$refs.textarea).blur();
+                const e = this.$refs.input || this.$refs.textarea;
+                if (e) {
+                    e.blur();
+                }
                 this.$emit('blur');
             },
             focus() {


### PR DESCRIPTION
### What was a problem?

Fix undefined exception, see screenshot.

![possible recomponents bug](https://user-images.githubusercontent.com/4344909/69597408-dd998a80-1040-11ea-8ecc-2419cc6b68c8.gif)

### How this PR fixes the problem?

RInput itself doesn't have this bug, but if another component extends it. eg `v-inline-input.vue`, as the view is not rendered, so undefined exception. adding `if` fixed this small bug.

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions
