### PR TITLE
Decouple rtabs header

### DIFF
--- a/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
+++ b/packages/recomponents/src/components/r-tabs/__snapshots__/r-tabs.spec.js.snap
@@ -3,10 +3,10 @@
 exports[`r-tabs.vue should open current route tab 1`] = `
 <div>
   <div role="tablist" class="r-tab">
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-custom-id-1" aria-controls="tabpanel-custom-id-1" class="r-tab-link">
+    <div class="r-tab-item"><button to="[object Object]" id="tab-custom-id-1" role="tab" aria-controls="tabpanel-custom-id-1" class="r-tab-link">
         Tab 1
       </button></div>
-    <div class="r-tab-item"><button to="[object Object]" role="tab" id="tab-custom-id-2" aria-controls="tabpanel-custom-id-2" class="r-tab-link is-active">
+    <div class="r-tab-item"><button to="[object Object]" id="tab-custom-id-2" role="tab" aria-controls="tabpanel-custom-id-2" class="r-tab-link is-active">
         Tab 2
       </button></div>
   </div>

--- a/packages/recomponents/src/components/r-tabs/r-tabs.md
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.md
@@ -10,6 +10,8 @@ There are 2 component: `r-tabs` and `r-tab`.
 | divided      | boolean     | `false`       |
 | menuClass    | string      |               |
 | contentClass | string      |               |
+| tabHeaderMode | boolean    | `false`       |
+
 ### Slots
 
 This component has 1 **required** slot that can be filled by any quantity of `r-tab` components.
@@ -21,6 +23,7 @@ This component has 1 **required** slot that can be filled by any quantity of `r-
 |------------| --------------------|---------------|
 | name       | string (required)   |               |
 | value      | string              |               |
+| panelId    | string (optional)   |               |
 | active     | boolean             | `false`       |
 | to         | [object, undefined] |               |
 
@@ -28,10 +31,36 @@ This component has 1 **required** slot that can be filled by any quantity of `r-
 
 This component has 1 **required** slot that can be filled with any html markup or vue components - the content of tab
 
+### Modes  
+*Standard*  
+
+In this mode we have a contentful header of tabs, where each `tab` in the header has a corresponding `tabpanel`.  
+  
+```html  
+<r-tabs>  
+    <r-tab v-for="(tab, tabIndex) in tabs"  
+            :key="tabIndex"  
+            :name="tab.name">  
+            {{tab.content}}  
+    </r-tab>  
+</r-tabs>  
+```  
+
+*Header only mode*  
+
+In this mode we have a contentless header of `tabs` that is independent of `tabpanels`.
+Ideally, when using this mode, we do not want there to be any content in `<r-tab></r-tab>` in order to avoid creating unnecessary DOM elements.
+
+```html
+<r-tabs tabHeaderMode="true">
+    <r-tab v-for="(tab, tabIndex) in tabs" :name="tab.name"></r-tab>
+</r-tabs>
+```
+
 
 ### Usage
 
-This component can be used in two modes:
+This component can be used in two different ways:
 
 #### Webcomponent module
 

--- a/packages/recomponents/src/components/r-tabs/r-tabs.story.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.story.js
@@ -10,13 +10,17 @@ storiesOf('Components', module)
                 <r-tabs :divided="divided"
                         :menuClass="menuClass"
                         :contentClass="contentClass"
-                        :tabHeaderMode="true"
+                        :tabHeaderMode="tabHeaderMode"
                         @tab-selected="tabSelected"
                 >
-                    <r-tab v-for="(tab, tabIndex) in contentlessTabs"
+                    <r-tab v-for="(tab, tabIndex) in tabs"
                             :key="tabIndex"
                             :name="tab.name"
-                    />
+                    >
+                        <template v-if="!tabHeaderMode">
+                            {{tab.content}}
+                        </template>
+                   </r-tab>
                 </r-tabs>
             </div>
         `,
@@ -27,6 +31,9 @@ storiesOf('Components', module)
             divided: {
                 default: boolean('Divided', false),
             },
+            tabHeaderMode: {
+                default: boolean('Tab Header Mode', false),
+            },
             menuClass: {
                 default: text('Menu class', ''),
             },
@@ -36,14 +43,9 @@ storiesOf('Components', module)
         },
         data: () => ({
             tabs: [
-                {name: 'Tab 1', resource: 'Tab 1 Content'},
-                {name: 'Tab 2', resource: 'Tab 2 Content'},
-                {name: 'Tab 3', resource: 'Tab 3 Content'},
-            ],
-            contentlessTabs: [
-                {name: 'Contentless 1'},
-                {name: 'Contentless 2'},
-                {name: 'Contentless 3'},
+                {name: 'Tab 1', content: 'Tab 1 Content'},
+                {name: 'Tab 2', content: 'Tab 2 Content'},
+                {name: 'Tab 3', content: 'Tab 3 Content'},
             ],
         }),
     }), {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.story.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.story.js
@@ -11,9 +11,12 @@ storiesOf('Components', module)
                         :menuClass="menuClass"
                         :contentClass="contentClass"
                         :tabHeaderMode="true"
-                        :justTabs="justTabs"
                         @tab-selected="tabSelected"
                 >
+                    <r-tab v-for="(tab, tabIndex) in contentlessTabs"
+                            :key="tabIndex"
+                            :name="tab.name"
+                    />
                 </r-tabs>
             </div>
         `,
@@ -37,10 +40,10 @@ storiesOf('Components', module)
                 {name: 'Tab 2', resource: 'Tab 2 Content'},
                 {name: 'Tab 3', resource: 'Tab 3 Content'},
             ],
-            justTabs: [
-                {name: 'Just 1'},
-                {name: 'Just 2'},
-                {name: 'Just 3'},
+            contentlessTabs: [
+                {name: 'Contentless 1'},
+                {name: 'Contentless 2'},
+                {name: 'Contentless 3'},
             ],
         }),
     }), {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.story.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.story.js
@@ -10,14 +10,10 @@ storiesOf('Components', module)
                 <r-tabs :divided="divided"
                         :menuClass="menuClass"
                         :contentClass="contentClass"
+                        :tabHeaderMode="true"
+                        :justTabs="justTabs"
                         @tab-selected="tabSelected"
                 >
-                    <r-tab v-for="(tab, tabIndex) in tabs"
-                           :key="tabIndex"
-                           :name="tab.name"
-                    >
-                        {{tab.resource}}
-                    </r-tab>
                 </r-tabs>
             </div>
         `,
@@ -40,6 +36,11 @@ storiesOf('Components', module)
                 {name: 'Tab 1', resource: 'Tab 1 Content'},
                 {name: 'Tab 2', resource: 'Tab 2 Content'},
                 {name: 'Tab 3', resource: 'Tab 3 Content'},
+            ],
+            justTabs: [
+                {name: 'Just 1'},
+                {name: 'Just 2'},
+                {name: 'Just 3'},
             ],
         }),
     }), {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -16,7 +16,7 @@
                 <button v-else
                         @click="selectTab(tab, index)"
                         role="tab"
-                        :id="tab. tabId"
+                        :id="tab.tabId"
                         :aria-controls="tab.tabPanelId"
                         class="r-tab-link"
                         :class="{'is-active': tab.isActive}"
@@ -51,7 +51,6 @@
                 type: Boolean,
                 default: false,
             },
-            contentlessTabs: Array,
         },
         watch: {
             $route(to, from) {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -5,8 +5,8 @@
                 <button v-if="tab.to"
                         :to="tab.to"
                         role="tab"
-                        :id="tab.computedTabId"
-                        :aria-controls="tab.computedPanelId"
+                        :id="tab.tabId"
+                        :aria-controls="tab.tabPanelId"
                         class="r-tab-link"
                         @click="selectTab(tab, index)"
                         :class="{'is-active': tab.isActive}"
@@ -16,8 +16,8 @@
                 <button v-else
                         @click="selectTab(tab, index)"
                         role="tab"
-                        :id="tab.computedTabId"
-                        :aria-controls="tab.computedPanelId"
+                        :id="tab. tabId"
+                        :aria-controls="tab.tabPanelId"
                         class="r-tab-link"
                         :class="{'is-active': tab.isActive}"
                 >

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -1,31 +1,44 @@
 <template>
     <div>
         <div class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]" role="tablist">
-            <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
-                <button v-if="tab.to"
-                        :to="tab.to"
-                        role="tab"
-                        :id="tab.tabId"
-                        :aria-controls="tab.tabPanelId"
-                        class="r-tab-link"
-                        @click="selectTab(tab, index)"
-                        :class="{'is-active': tab.isActive}"
-                >
-                    {{tab.name}}
-                </button>
-                <button v-else
-                        @click="selectTab(tab, index)"
-                        role="tab"
-                        :id="tab.tabId"
-                        :aria-controls="tab.tabPanelId"
-                        class="r-tab-link"
-                        :class="{'is-active': tab.isActive}"
-                >
-                    {{tab.name}}
-                </button>
-            </div>
+            <template v-if="tabHeaderMode && justTabs && justTabs.length > 0">
+                <div v-for="(tab, index) in justTabs" class="r-tab-item" :key="index">
+                    <button role="tab"
+                            :class="{'is-active': tab.isActive}"
+                            class="r-tab-link"
+                            @click="selectTab(tab, index)"
+                    >
+                        {{tab.name}}
+                    </button>
+                </div>
+            </template>
+            <template v-else>
+                <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
+                    <button v-if="tab.to"
+                            :to="tab.to"
+                            role="tab"
+                            :id="tab.computedTabId"
+                            :aria-controls="tab.computedPanelId"
+                            class="r-tab-link"
+                            @click="selectTab(tab, index)"
+                            :class="{'is-active': tab.isActive}"
+                    >
+                        {{tab.name}}
+                    </button>
+                    <button v-else
+                            @click="selectTab(tab, index)"
+                            role="tab"
+                            :id="tab.computedTabId"
+                            :aria-controls="tab.computedPanelId"
+                            class="r-tab-link"
+                            :class="{'is-active': tab.isActive}"
+                    >
+                        {{tab.name}}
+                    </button>
+                </div>
+            </template>
         </div>
-        <div class="r-tab-content" :class="contentClass">
+        <div class="r-tab-content" :class="contentClass" v-if="!tabHeaderMode">
             <slot></slot>
         </div>
     </div>
@@ -47,6 +60,11 @@
                 type: String,
                 default: '',
             },
+            tabHeaderMode: {
+                type: Boolean,
+                default: false
+            },
+            justTabs: Array
         },
         watch: {
             $route(to, from) {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -1,25 +1,14 @@
 <template>
     <div>
-        <div class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]" role="tablist">
+        <div class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]" :role="tabHeaderMode ? null : 'tablist'">
             <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
-                <button v-if="tab.to"
-                        :to="tab.to"
-                        role="tab"
+                <button :to="tab.to"
                         :id="tab.tabId"
-                        :aria-controls="tab.tabPanelId"
+                        :role="tabHeaderMode ? null : 'tab'"
+                        :aria-controls="tabHeaderMode ? null : tab.tabPanelId"
+                        :class="{'is-active': tab.isActive}"
                         class="r-tab-link"
                         @click="selectTab(tab, index)"
-                        :class="{'is-active': tab.isActive}"
-                >
-                    {{tab.name}}
-                </button>
-                <button v-else
-                        @click="selectTab(tab, index)"
-                        role="tab"
-                        :id="tab.tabId"
-                        :aria-controls="tab.tabPanelId"
-                        class="r-tab-link"
-                        :class="{'is-active': tab.isActive}"
                 >
                     {{tab.name}}
                 </button>

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -1,44 +1,31 @@
 <template>
     <div>
         <div class="r-tab" :class="[{'r-tab-divided': divided}, menuClass]" role="tablist">
-            <template v-if="tabHeaderMode && justTabs && justTabs.length > 0">
-                <div v-for="(tab, index) in justTabs" class="r-tab-item" :key="index">
-                    <button role="tab"
-                            :class="{'is-active': tab.isActive}"
-                            class="r-tab-link"
-                            @click="selectTab(tab, index)"
-                    >
-                        {{tab.name}}
-                    </button>
-                </div>
-            </template>
-            <template v-else>
-                <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
-                    <button v-if="tab.to"
-                            :to="tab.to"
-                            role="tab"
-                            :id="tab.computedTabId"
-                            :aria-controls="tab.computedPanelId"
-                            class="r-tab-link"
-                            @click="selectTab(tab, index)"
-                            :class="{'is-active': tab.isActive}"
-                    >
-                        {{tab.name}}
-                    </button>
-                    <button v-else
-                            @click="selectTab(tab, index)"
-                            role="tab"
-                            :id="tab.computedTabId"
-                            :aria-controls="tab.computedPanelId"
-                            class="r-tab-link"
-                            :class="{'is-active': tab.isActive}"
-                    >
-                        {{tab.name}}
-                    </button>
-                </div>
-            </template>
+            <div v-for="(tab, index) in tabs" class="r-tab-item" :key="index">
+                <button v-if="tab.to"
+                        :to="tab.to"
+                        role="tab"
+                        :id="tab.computedTabId"
+                        :aria-controls="tab.computedPanelId"
+                        class="r-tab-link"
+                        @click="selectTab(tab, index)"
+                        :class="{'is-active': tab.isActive}"
+                >
+                    {{tab.name}}
+                </button>
+                <button v-else
+                        @click="selectTab(tab, index)"
+                        role="tab"
+                        :id="tab.computedTabId"
+                        :aria-controls="tab.computedPanelId"
+                        class="r-tab-link"
+                        :class="{'is-active': tab.isActive}"
+                >
+                    {{tab.name}}
+                </button>
+            </div>
         </div>
-        <div class="r-tab-content" :class="contentClass" v-if="!tabHeaderMode">
+        <div class="r-tab-content" :class="contentClass" v-show="!tabHeaderMode">
             <slot></slot>
         </div>
     </div>
@@ -64,7 +51,7 @@
                 type: Boolean,
                 default: false
             },
-            justTabs: Array
+            contentlessTabs: Array
         },
         watch: {
             $route(to, from) {

--- a/packages/recomponents/src/components/r-tabs/r-tabs.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.vue
@@ -49,9 +49,9 @@
             },
             tabHeaderMode: {
                 type: Boolean,
-                default: false
+                default: false,
             },
-            contentlessTabs: Array
+            contentlessTabs: Array,
         },
         watch: {
             $route(to, from) {


### PR DESCRIPTION
This PR adds a new mode for using the `r-tabs`.
The new mode is called `tabHeaderMode` and allows for `r-tabs` to be used as a standalone header, without an attached tabpanel.