### PR TITLE
fix(r-select): Align close icon in r-select tag badges

### DIFF
--- a/packages/recomponents/src/components/r-select/r-select.scss
+++ b/packages/recomponents/src/components/r-select/r-select.scss
@@ -158,6 +158,7 @@ fieldset[disabled] .r-select {
 .r-select__tags .r-badge .r-badge-icon {
     width: 16px;
     height: 16px;
+    vertical-align: middle;
 }
 
 .is-error .r-select__tags {


### PR DESCRIPTION
r-select tag badges close icon should be aligned in the middle.