### PR TITLE
Add global test setup and register directives globally

### DIFF
--- a/packages/recomponents/jest.config.js
+++ b/packages/recomponents/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
         'vue',
         'json',
     ],
+    setupFiles: ['./src/setup-test.js'],
     transform: {
         '^.+\\.vue$': 'vue-jest',
         '^.+\\.jsx?$': 'babel-jest',

--- a/packages/recomponents/src/components/index.js
+++ b/packages/recomponents/src/components/index.js
@@ -1,0 +1,39 @@
+import RBadge from './r-badge/r-badge.vue';
+import RButton from './r-button/r-button.vue';
+import RButtonGroup from './r-button-group/r-button-group.vue';
+import RCheckbox from './r-checkbox/r-checkbox.vue';
+import RPopper from './r-popper/r-popper.vue';
+import RIcon from './r-icon/r-icon.vue';
+import RIconButton from './r-icon-button/r-icon-button.vue';
+import RImg from './r-img/r-img.vue';
+import RInput from './r-input/r-input.vue';
+import RLoader from './r-loader/r-loader.vue';
+import RModal from './r-modal/r-modal.vue';
+import RPagination from './r-pagination/r-pagination.vue';
+import RRadio from './r-radio/r-radio.vue';
+import RTab from './r-tabs/r-tab.vue';
+import RTabs from './r-tabs/r-tabs.vue';
+import RSelect from './r-select/r-select.vue';
+import RTile from './r-tile/r-tile.vue';
+import RDateInput from './r-date-input/r-date-input.vue';
+
+export {
+    RBadge,
+    RButton,
+    RButtonGroup,
+    RCheckbox,
+    RIcon,
+    RIconButton,
+    RImg,
+    RInput,
+    RLoader,
+    RModal,
+    RPagination,
+    RPopper,
+    RRadio,
+    RSelect,
+    RTab,
+    RTabs,
+    RTile,
+    RDateInput,
+};

--- a/packages/recomponents/src/components/r-select/r-select.spec.js
+++ b/packages/recomponents/src/components/r-select/r-select.spec.js
@@ -1,10 +1,6 @@
-import {shallowMount, createLocalVue} from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 import {renderToString} from '@vue/server-test-utils';
 import RSelect from './r-select.vue';
-import RFsBlock from '../../directives/r-fs-block';
-
-const localVue = createLocalVue();
-localVue.directive('fs-block', RFsBlock);
 
 describe('r-select.vue', () => {
     it('should render Wrapper and match snapshot', () => {
@@ -14,7 +10,6 @@ describe('r-select.vue', () => {
                 id: 'id',
                 options: [{val: 1, label: '1'}, {val: 2, label: '2'}],
             },
-            localVue,
         });
 
         expect(wrapper).toMatchSnapshot();

--- a/packages/recomponents/src/directives/index.js
+++ b/packages/recomponents/src/directives/index.js
@@ -1,0 +1,13 @@
+import RTooltip from './r-tooltip/r-tooltip';
+import RFsBlock from './r-fs-block';
+import RLazy from './r-lazy';
+import RContent from './r-content/r-content';
+import RClickOutside from './r-click-outside/r-click-outside';
+
+export {
+    RTooltip,
+    RFsBlock,
+    RLazy,
+    RContent,
+    RClickOutside,
+};

--- a/packages/recomponents/src/directives/r-click-outside/r-click-outside.spec.js
+++ b/packages/recomponents/src/directives/r-click-outside/r-click-outside.spec.js
@@ -1,5 +1,4 @@
 import {mount, createLocalVue} from '@vue/test-utils';
-import RClickOutside from './r-click-outside';
 import RButton from '../../components/r-button/r-button.vue';
 
 const mockTemplate = {
@@ -14,7 +13,6 @@ const mockTemplate = {
 const localVue = createLocalVue();
 
 localVue.component('r-button', RButton);
-localVue.directive('click-outside', RClickOutside);
 
 describe('r-click-outside.js', () => {
     it('Shouldn handle outside click', () => {

--- a/packages/recomponents/src/directives/r-content/r-content.spec.js
+++ b/packages/recomponents/src/directives/r-content/r-content.spec.js
@@ -1,4 +1,4 @@
-import {createLocalVue, shallowMount} from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 import RContent from './r-content';
 
 const mockTemplate = {
@@ -15,12 +15,7 @@ const mockTemplate = {
                 </div>`,
 };
 
-const localVue = createLocalVue();
-localVue.directive('content', RContent);
-
-const wrapper = shallowMount(mockTemplate, {
-    localVue,
-});
+const wrapper = shallowMount(mockTemplate);
 
 describe('r-content.js', () => {
     it('Should render the correct HTML structure', () => {

--- a/packages/recomponents/src/directives/r-content/r-content.spec.js
+++ b/packages/recomponents/src/directives/r-content/r-content.spec.js
@@ -1,5 +1,4 @@
 import {shallowMount} from '@vue/test-utils';
-import RContent from './r-content';
 
 const mockTemplate = {
     template: `

--- a/packages/recomponents/src/directives/r-tooltip/r-tooltip.spec.js
+++ b/packages/recomponents/src/directives/r-tooltip/r-tooltip.spec.js
@@ -1,7 +1,6 @@
 import {createLocalVue, mount} from '@vue/test-utils';
 
 import RButton from '../../components/r-button/r-button.vue';
-import RTooltip from './r-tooltip';
 
 const directiveValue = `tooltip-text-${new Date().getTime()}`;
 
@@ -12,10 +11,9 @@ const mockTemplate = {
 const localVue = createLocalVue();
 
 localVue.component('r-button', RButton);
-localVue.directive('tooltip', RTooltip);
 
 describe('r-tooltip.js', () => {
-    it('Shouldn render the tooltip', () => {
+    it('Should render the tooltip', () => {
         const wrapper = mount(mockTemplate, {
             localVue,
             attachToDocument: true,

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -1,63 +1,13 @@
 import './polyfill';
 
-import RTooltip from './directives/r-tooltip/r-tooltip';
-import RFsBlock from './directives/r-fs-block';
-import RLazy from './directives/r-lazy';
-import RContent from './directives/r-content/r-content';
-import RClickOutside from './directives/r-click-outside/r-click-outside';
-
 import './styles/typography.scss';
 import './styles/helpers.scss';
 import './styles/theme.scss';
 
-import RBadge from './components/r-badge/r-badge.vue';
-import RButton from './components/r-button/r-button.vue';
-import RButtonGroup from './components/r-button-group/r-button-group.vue';
-import RCheckbox from './components/r-checkbox/r-checkbox.vue';
-import RPopper from './components/r-popper/r-popper.vue';
-import RIcon from './components/r-icon/r-icon.vue';
-import RIconButton from './components/r-icon-button/r-icon-button.vue';
-import RImg from './components/r-img/r-img.vue';
-import RInput from './components/r-input/r-input.vue';
-import RLoader from './components/r-loader/r-loader.vue';
-import RModal from './components/r-modal/r-modal.vue';
-import RPagination from './components/r-pagination/r-pagination.vue';
-import RRadio from './components/r-radio/r-radio.vue';
-import RTab from './components/r-tabs/r-tab.vue';
-import RTabs from './components/r-tabs/r-tabs.vue';
-import RSelect from './components/r-select/r-select.vue';
-import RTile from './components/r-tile/r-tile.vue';
-import RDateInput from './components/r-date-input/r-date-input.vue';
+import kebabCase from './common/helpers/kebab-case';
 
-const components = {
-    RBadge,
-    RButton,
-    RButtonGroup,
-    RCheckbox,
-    RIcon,
-    RIconButton,
-    RImg,
-    RInput,
-    RLoader,
-    RModal,
-    RPagination,
-    RPopper,
-    RRadio,
-    RSelect,
-    RTab,
-    RTabs,
-    RTile,
-    RDateInput,
-};
-
-const directives = {
-    tooltip: RTooltip,
-    'fs-block': RFsBlock,
-    lazy: RLazy,
-    content: RContent,
-    'click-outside': RClickOutside,
-};
-
+import * as components from './components';
+import * as directives from './directives';
 
 function install(Vue) {
     /**
@@ -68,41 +18,15 @@ function install(Vue) {
     });
 
     /**
-     * Injecting all directives according to the defined directive keys
+     * Injecting all directives without 'r' prefix
      */
-    Object.entries(directives).forEach(([key, value]) => {
-        Vue.directive(key, value);
+    Object.keys(directives).forEach((key) => {
+        Vue.directive(kebabCase(key.substr(1)), directives[key]);
     });
 }
 
-export {
-    RTooltip,
-    RFsBlock,
-    RLazy,
-    RContent,
-    RClickOutside,
-};
-
-export {
-    RBadge,
-    RButton,
-    RButtonGroup,
-    RCheckbox,
-    RIcon,
-    RIconButton,
-    RImg,
-    RInput,
-    RLoader,
-    RModal,
-    RPagination,
-    RPopper,
-    RRadio,
-    RSelect,
-    RTab,
-    RTabs,
-    RTile,
-    RDateInput,
-};
+export * from './directives';
+export * from './components';
 
 export default {
     install,

--- a/packages/recomponents/src/setup-test.js
+++ b/packages/recomponents/src/setup-test.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+
+import * as directives from './directives';
+import kebabCase from './common/helpers/kebab-case';
+
+// Register directives in the global vue instance,
+// as they are used in most of our components
+Object.keys(directives).forEach((key) => {
+    Vue.directive(kebabCase(key.substr(1)), directives[key]);
+});


### PR DESCRIPTION
### What was a problem?

Our components use directives, but manually importing and registering directives for each test file is cumbersome and error prone. 

### How this PR fixes the problem?

This PR adds a setup file which registers all directives to the global Vue object before tests run. This is *technically* not the cleanest way to run tests, but it is very low-risk and, in my opinion, easier to maintain.

I'm open to feedback if the team thinks this approach is not appropriate!