### PR TITLE
fix(RSelect): disallow use of v-html to prevent XSS attack

### DIFF
--- a/packages/recomponents/.eslintrc
+++ b/packages/recomponents/.eslintrc
@@ -22,6 +22,7 @@
         "no-param-reassign": 0,
         "quotes": ["error", "single", {"allowTemplateLiterals": true}],
         "vue/script-indent": ["error", 4, {"baseIndent": 1, "switchCase": 1}],
+        "vue/no-v-html": 1,
         "no-underscore-dangle": ["error", {"allow": ["_links", "_embedded"]}],
         "no-nested-ternary": 1,
         "no-useless-escape": 1,

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -190,7 +190,7 @@
                 </div>
             </transition>
         </div>
-        <span v-if="helpText" class="r-field-caption" v-html="helpText"></span>
+        <span v-if="helpText" class="r-field-caption">{{helpText}}</span>
     </div>
 </template>
 


### PR DESCRIPTION
### What was a problem?

disallow use of v-html to prevent XSS attack

### How this PR fixes the problem?

1. add rule `vue/no-v-html` in eslint
2. remove `v-html` in r-select

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions