### PR TITLE
Fixed H1 Leading

### DIFF
--- a/packages/recomponents/src/styles/recomm.scss
+++ b/packages/recomponents/src/styles/recomm.scss
@@ -814,7 +814,7 @@ h1, .h1 {
     line-height: var(--font-line-height-h1);
     margin-top: 4.0rem;
     margin-bottom: 2.0rem;
-    letter-spacing: -0.6rem;
+    letter-spacing: -0.06rem;
     font-family: var(--secondary-font-stack);
 }
 


### PR DESCRIPTION
### What was a problem?

Leading is wrong on H1

### How this PR fixes the problem?

Fix error when moving from PX to REM => `-0.6px` should be `-0.06rem`

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

{Please write here}