### PR TITLE
fix(RPopper): fix the transition bug

### DIFF
--- a/packages/recomponents/src/components/r-popper/r-popper.scss
+++ b/packages/recomponents/src/components/r-popper/r-popper.scss
@@ -1,3 +1,8 @@
+.r-popper-content-wrapper > *:only-child {
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
 .r-popper {
     display: inline-block;
     position: relative;

--- a/packages/recomponents/src/components/r-popper/r-popper.vue
+++ b/packages/recomponents/src/components/r-popper/r-popper.vue
@@ -194,8 +194,10 @@
                 this.isPopperVisible = visible;
                 await this.$nextTick(); // await for contentEl to be visible before trying to access it
                 if (this.contentEl && this.contentEl.hasChildNodes()) {
-                    this.contentEl.firstChild.style = `transition-duration: ${this.duration}s`;
-                    this.positionContent();
+                    if (this.contentEl.firstChild.classList) {
+                        this.contentEl.firstChild.style.transitionDuration = `${this.duration}s`;
+                        this.positionContent();
+                    }
                 }
                 this.$emit('toggle', visible !== this.isPopperVisible);
                 this.$emit(visible ? 'toggle-on' : 'toggle-off');

--- a/packages/recomponents/src/components/r-popper/r-popper.vue
+++ b/packages/recomponents/src/components/r-popper/r-popper.vue
@@ -193,11 +193,9 @@
                 }
                 this.isPopperVisible = visible;
                 await this.$nextTick(); // await for contentEl to be visible before trying to access it
-                if (this.contentEl && this.contentEl.hasChildNodes()) {
-                    if (this.contentEl.firstChild.classList) {
-                        this.contentEl.firstChild.style.transitionDuration = `${this.duration}s`;
-                        this.positionContent();
-                    }
+                if (this.contentEl && this.contentEl.hasChildNodes() && this.contentEl.firstChild.classList) {
+                    this.contentEl.firstChild.style.transitionDuration = `${this.duration}s`;
+                    this.positionContent();
                 }
                 this.$emit('toggle', visible !== this.isPopperVisible);
                 this.$emit(visible ? 'toggle-on' : 'toggle-off');


### PR DESCRIPTION
### What was a problem?

I updated the transition feature for the RPopper, no bugs in storybook, but it causes bugs in Recomm. Luckily is that we still didn't use the latest version, so NO real bugs happened in Recomm :-) 

### How this PR fixes the problem?

- fixed the error on the console: `this.contentEL.childNodes[0].getBoundingClientRect is not a function`
- fixed the position issue.
- maked the content of RPopper visible

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

Sometimes the demo is OK in storybook, it doesn't always mean it's OK in Recomm as Recomm is more complex, the demo doesn't cover all the cases. so still need to have a test in Recomm if required.