### PR TITLE
fix(RModal): delete appear event

### DIFF
--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -35,7 +35,7 @@
                                 <r-button
                                         :class="{'r-inline-s': $slots['actions']}"
                                         @click="close" aria-label="close">
-                                    {{cancelLabel}}Q
+                                    {{cancelLabel}}
                                 </r-button>
                                 <slot name="actions"/>
                             </slot>

--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <transition name="r-modal" @appear="appear" @enter="enter" @leave="leave">
+    <transition name="r-modal" @enter="enter" @leave="leave">
         <div @mousedown="close"
              tabindex="0"
              ref="container"
@@ -35,7 +35,7 @@
                                 <r-button
                                         :class="{'r-inline-s': $slots['actions']}"
                                         @click="close" aria-label="close">
-                                    {{cancelLabel}}
+                                    {{cancelLabel}}Q
                                 </r-button>
                                 <slot name="actions"/>
                             </slot>
@@ -163,10 +163,6 @@
             enter() {
                 this.focus();
                 this.$emit('enter');
-            },
-            appear() {
-                this.focus();
-                this.$emit('appear');
             },
             leave() {
                 // TODO styles no-scroll


### PR DESCRIPTION
### What was a problem?

`appear` event is triggered even the RModal is hidden, so add `r-no-scroll` to the body and cause the whole page can't be scrollable, which is bad.

### How this PR fixes the problem?

Just removed `appear` event as I noticed this event is never used in Recomm, and fixed the scroll bug.

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions
