### PR TITLE
Fix popper animation

### DIFF
--- a/packages/recomponents/src/components/r-popper/r-popper.scss
+++ b/packages/recomponents/src/components/r-popper/r-popper.scss
@@ -1,6 +1,6 @@
 .r-popper-content-wrapper > *:only-child {
-    visibility: visible !important;
-    opacity: 1 !important;
+    visibility: visible;
+    opacity: 1;
 }
 
 .r-popper {
@@ -99,6 +99,7 @@
     box-shadow: var(--popover-box-shadow);
     border-radius: var(--popover-border-radius);
     z-index: var(--popover-z-index);
+    transition: var(--popover-transition);
 }
 
 .r-popover.r-popover-centered {

--- a/packages/recomponents/src/styles/animate.scss
+++ b/packages/recomponents/src/styles/animate.scss
@@ -7,25 +7,25 @@
 }
 
 .fade-enter, .fade-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
 }
 
 .left-enter, .left-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
     transform: translateX(-12px);
 }
 
 .right-enter, .right-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
     transform: translateX(12px);
 }
 
 .bottom-enter, .bottom-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
     transform: translateY(12px);
 }
 
 .top-enter, .top-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
     transform: translateY(-12px);
 }


### PR DESCRIPTION
### What was a problem?

Opacity was not active during animation

### How this PR fixes the problem?

Disable ability to override opacity for element in <transition> component

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

* https://vuejs.org/v2/guide/transitions.html#Transition-Classes