### PR TITLE
add static directory option to storybook build script (GWY-13645)

### DIFF
--- a/packages/recomponents/README.md
+++ b/packages/recomponents/README.md
@@ -53,6 +53,28 @@ Or bundled with webpack:
 
 We prefer [Storybook](https://storybook.js.org/) to plain-old documentation. [Check it out](https://recomponents.rebilly.com/) to see all of our components on display, with a comprehensive description and the ability to tweak properties and slots.
 
+## Building storybook
+Building (will generate bundled version in ../../docs folder):
+
+```bash
+npm run build-storybook
+yarn build-storybook
+```
+
+### Serving built storybook (from docs folder)
+
+If you want to serve the built version you can install [http-server](https://www.npmjs.com/package/http-server):
+
+```bash
+    yarn global add http-server
+    npm install http-server -g
+```
+
+and run: 
+```bash
+    yarn serve-built-storybook
+    npm run serve-built-storybook
+```
 ## Licence
 
 Recomponents are open source and released under the MIT Licence.

--- a/packages/recomponents/package.json
+++ b/packages/recomponents/package.json
@@ -18,8 +18,9 @@
     "build:lib": "vue-cli-service build --target lib --name recomponents 'src/index.js' --no-clean",
     "build:theme": "node-sass src/styles/recomm.scss dist/recomm.css",
     "clean:dist": "rimraf ./dist/**/*",
-    "storybook": "start-storybook -p 9001  -s public",
-    "build-storybook": "build-storybook -c .storybook -o ../../docs",
+    "storybook": "start-storybook -p 9001  -s ./public",
+    "build-storybook": "build-storybook -c .storybook -o ../../docs -s ./public",
+    "serve-built-storybook": "http-server ../../docs",
     "build-image-snapshots": "cross-env NODE_ENV=test jest --projects=./.image-snapshots",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
### What was a problem?

We forgot to add -s option when building storybook so the static was not found giving 404 errors in the deployed version of storybook

### How this PR fixes the problem?

Adding `-s ./public` to `build-storybook` script in` package.json` so that static contents are copied when building. 

### Check lists

- [ x] Readme file updated with actual description and example
