### PR TITLE
fix: avoid quotes in animation scss to avoid invalid syntax error

### DIFF
--- a/packages/recomponents/src/components/r-toast/r-toast.scss
+++ b/packages/recomponents/src/components/r-toast/r-toast.scss
@@ -22,7 +22,7 @@
     opacity: 0;
     transition: var(--toast-transition);
     color: var(--toast-text-color);
-    animation: 'r-toaster-animation 0.4s ease-out';
+    animation: r-toaster-animation 0.4s ease-out;
 }
 
 .r-toast.is-closable {


### PR DESCRIPTION
### What was a problem?

Defining the r-toast animation with quotes in the scss file was causing an invalid generated css that prevented the animation from working. 