### PR TITLE
Add click event to r-badge

### DIFF
--- a/packages/recomponents/src/components/r-badge/r-badge.spec.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.spec.js
@@ -80,4 +80,15 @@ describe('r-badge.vue', () => {
         wrapper.find(RIcon).trigger('click');
         expect(wrapper.emitted('close')).not.toBe(undefined);
     });
+
+    it('should emit event click on click', () => {
+        const wrapper = mount(RBadge, {
+            propsData: {
+                close: true,
+            },
+        });
+
+        wrapper.trigger('click');
+        expect(wrapper.emitted('click')).not.toBe(undefined);
+    });
 });

--- a/packages/recomponents/src/components/r-badge/r-badge.vue
+++ b/packages/recomponents/src/components/r-badge/r-badge.vue
@@ -1,12 +1,14 @@
 <template>
-    <span class="r-component r-badge" :class="classes">
+    <span
+        class="r-component r-badge"
+        :class="classes"
+        @click="$emit('click')">
         <slot>Badge</slot>
         <r-icon v-if="close"
                 aria-hidden="true"
                 class="r-icon-gray r-badge-icon"
-                @click="$emit('close')"
                 @keypress.enter.prevent="$emit('close')"
-                @mousedown.prevent="$emit('close')"
+                @click.capture.stop="$emit('close')"
                 icon="close-s"/>
     </span>
 </template>


### PR DESCRIPTION
### What was a problem?

r-badge did not emit a click event

### How this PR fixes the problem?

this PR adds a click event when clicking on a badge, and properly stops propagation of the click on the close icon if present. 