### PR TITLE
fix(RBadge): improve RBadge tests and test descriptors

### DIFF
--- a/packages/recomponents/src/components/r-badge/r-badge.spec.js
+++ b/packages/recomponents/src/components/r-badge/r-badge.spec.js
@@ -70,7 +70,7 @@ describe('r-badge.vue', () => {
         expect(wrapper.contains(RIcon)).toBe(true);
     });
 
-    it('should emit event click on close icon', () => {
+    it('should emit close event when clicking on close icon', () => {
         const wrapper = mount(RBadge, {
             propsData: {
                 close: true,
@@ -81,7 +81,18 @@ describe('r-badge.vue', () => {
         expect(wrapper.emitted('close')).not.toBe(undefined);
     });
 
-    it('should emit event click on click', () => {
+    it('should not emit click event when clicking on close icon', () => {
+        const wrapper = mount(RBadge, {
+            propsData: {
+                close: true,
+            },
+        });
+
+        wrapper.find(RIcon).trigger('click');
+        expect(wrapper.emitted('click')).toBe(undefined);
+    });
+
+    it('should emit click event when clicking on badge', () => {
         const wrapper = mount(RBadge, {
             propsData: {
                 close: true,


### PR DESCRIPTION
### What was a problem?

The RBadge test descriptors were a bit confusing, and the suite was missing one test.

### How this PR fixes the problem?

Updates the descriptions for each test, and adds a test case for clicking on the `close` button to ensure it does not emit a `click` event in that case (only a `close` event)