### PR TITLE
fix(component): Cleanup RCheckbox styles

### DIFF
--- a/packages/recomponents/.storybook/webpack.config.js
+++ b/packages/recomponents/.storybook/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = function({ config }) {
                 loader: 'sass-loader',
                 options: {
                     prependData: `
-                        @import "src/styles/recomm.scss";
                         @import "src/styles/mixins.scss";
                     `,
                 }

--- a/packages/recomponents/src/components/r-checkbox/r-checkbox.scss
+++ b/packages/recomponents/src/components/r-checkbox/r-checkbox.scss
@@ -14,41 +14,41 @@
     cursor: pointer;
 
     &:checked ~ .r-field-checkbox-style {
-        background: var(--checkbox-checked-background);
-        box-shadow: var(--checkbox-checked-box-shadow);
-        border: var(--checkbox-checked-border);
+        background: var(--mono-color-0);
+        box-shadow: 0 0 0 1px var(--primary-color) inset, 0 1px 2px 0 var(--mono-color-300) inset, 0 0 0 1px var(--primary-color);
+        border: none;
     }
 
     &:focus ~ .r-field-checkbox-style {
-        background: var(--checkbox-focus-background);
-        box-shadow: var(--checkbox-focus-box-shadow);
-        border: var(--checkbox-focus-border);
+        background: var(--mono-color-0);
+        box-shadow: 0 0 0 1px var(--primary-color) inset, 0 1px 2px 0 var(--mono-color-300) inset, 0 0 0 1px var(--primary-color);
+        border: none;
     }
 
     &:checked ~ .r-field-checkbox-style .r-icon {
-        fill: var(--checkbox-checked-icon-color);
+        fill: var(--primary-color);
         opacity: 1;
     }
 
     &[disabled] ~ .r-field-checkbox-style {
-        background: var(--checkbox-disabled-background);
-        box-shadow: var(--checkbox-disabled-box-shadow);
+        background: var(--mono-color-100);
+        box-shadow: 0 0 0 1px var(--gray-color) inset;
     }
 }
 
 .r-field-checkbox-style {
     cursor: pointer;
     box-sizing: border-box;
-    background: var(--checkbox-background);
+    background: var(---mono-color-0);
     height: var(--space-m);
     width: var(--space-m);
     position: absolute;
     top: var(--space-xxs);
     left: var(--space-xxs);
-    border-radius: var(--checkbox-border-radius);
-    box-shadow: var(--checkbox-box-shadow);
-    transition: var(--checkbox-transition);
-    border: var(--checkbox-border);
+    border-radius: var(--border-radius-xxs);
+    box-shadow: 0 0 0 1px var(--gray-color) inset, 0 1px 2px 0 var(--mono-color-300) inset;
+    transition: box-shadow var(--timing-100) var(--animation-ease);
+    border: none;
 }
 
 .r-field-checkbox-style .r-icon {

--- a/packages/recomponents/src/components/r-input/r-input.scss
+++ b/packages/recomponents/src/components/r-input/r-input.scss
@@ -1,7 +1,3 @@
-// -----------------------------------------------------------------------------
-// This file contains all styles related to the icon component.
-// -----------------------------------------------------------------------------
-
 .r-field,
 .r-field-control {
     position: relative;
@@ -132,7 +128,7 @@ textarea.r-field-input {
     padding-left: 0;
 }
 
-.r-field-addon .r-field-label-toggle {
+.r-field-addon {
     margin-bottom: 0;
 }
 

--- a/packages/recomponents/src/styles/theme.scss
+++ b/packages/recomponents/src/styles/theme.scss
@@ -177,23 +177,6 @@ body, .article {
     --button-icon-primary-color: var(--mono-color-0);
     --button-icon-danger-color: var(--mono-color-0);
 
-    // Checkboxes
-    // ------------------------------------------------
-    --checkbox-transition: box-shadow var(--timing-100) var(--animation-ease);
-    --checkbox-background: var(--mono-color-0);
-    --checkbox-border-radius: var(--border-radius-xxs);
-    --checkbox-box-shadow: 0 0 0 1px var(--gray-color) inset, 0 1px 2px 0 var(--mono-color-300) inset;
-    --checkbox-border: none;
-    --checkbox-checked-background: var(--mono-color-0);
-    --checkbox-checked-box-shadow: 0 0 0 1px var(--primary-color) inset, 0 1px 2px 0 var(--mono-color-300) inset, 0 0 0 1px var(--primary-color);
-    --checkbox-checked-border: none;
-    --checkbox-checked-icon-color: var(--primary-color);
-    --checkbox-focus-background: var(--mono-color-0);
-    --checkbox-focus-box-shadow: 0 0 0 1px var(--primary-color) inset, 0 1px 2px 0 var(--mono-color-300) inset, 0 0 0 1px var(--primary-color);
-    --checkbox-focus-border: none;
-    --checkbox-disabled-background: var(--mono-color-100);
-    --checkbox-disabled-box-shadow: 0 0 0 1px var(--gray-color) inset;
-
     // Radios
     // ------------------------------------------------
     --radio-transition: box-shadow var(--timing-100) var(--animation-ease);


### PR DESCRIPTION
### What was a problem?

Checkbox styles was inconsistent

### How this PR fixes the problem?

* Removes duplicated css variables usage
* Removes 2-level inheritance in variables

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments (if any)

Right now `r-field-label` and `r-field-label-toggle` can be used together because toggle override most of properties of default label - no need to update markup.