### PR TITLE
fix(RToast): Fix visual scroll bug

### DIFF
--- a/packages/recomponents/src/components/r-toast/r-toast.scss
+++ b/packages/recomponents/src/components/r-toast/r-toast.scss
@@ -3,8 +3,6 @@
     top: var(--toast-container-top);
     right: var(--toast-container-right);
     z-index: var(--toast-container-z-index);
-    min-width: 200px;
-    overflow-y: scroll;
 }
 
 .r-toast {


### PR DESCRIPTION
### What was a problem?

RToast was rendering strangely in Recomm, with a scrollbar appearing on the container. 

### How this PR fixes the problem?

This PR removes styles on the `r-toast-container` CSS class which did not match the original implementation from Recomm and which were causing the bug.