### PR TITLE
Add new method on rtoast

### DIFF
--- a/packages/recomponents/src/common/helpers/default-error-handler.js
+++ b/packages/recomponents/src/common/helpers/default-error-handler.js
@@ -19,7 +19,7 @@ class DefaultErrorHandler {
                     }
                     break;
                 case 500:
-                    errorMessages.push(`Something went wrong on our server, please contact support.`);
+                    errorMessages.push(`Something went wrong on our servers, please contact support.`);
                     break;
                 default:
                     errorMessages.push(defaultMessage);

--- a/packages/recomponents/src/common/helpers/default-error-handler.js
+++ b/packages/recomponents/src/common/helpers/default-error-handler.js
@@ -1,0 +1,41 @@
+class DefaultErrorHandler {
+    static parseError(error, defaultMessage = 'Something went wrong, please try again or contact support') {
+        let errorMessages = [];
+        if (error && error.status) {
+            switch (error.status) {
+                case 401:
+                case 404:
+                case 409:
+                case 400:
+                    errorMessages.push(error.message);
+                    break;
+                case 422:
+                    // TODO use invalidFields prop for better details when possible
+                    if (error.details && error.details.length) {
+                        errorMessages = [
+                            ...errorMessages,
+                            ...error.details,
+                        ];
+                    }
+                    break;
+                case 500:
+                    errorMessages.push(`Something went wrong on our server, please contact support.`);
+                    break;
+                default:
+                    errorMessages.push(defaultMessage);
+            }
+        } else if (error && error.name === 'RebillyConflictError') { // error status 409
+            errorMessages.push(error.message);
+        } else if (error && error.name === 'RebillyCanceledError') {
+            // ignore cancel error, request is canceled
+            return errorMessages;
+        }
+        if (errorMessages.length) {
+            return errorMessages;
+        }
+
+        return [defaultMessage];
+    }
+}
+
+export default DefaultErrorHandler;

--- a/packages/recomponents/src/components/r-toast/r-toast.spec.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.spec.js
@@ -68,4 +68,90 @@ describe('r-toast.vue', () => {
 
         expect(hasToastAppeared).toBe(true);
     });
+
+    describe('r-toast-manager default error handling', () => {
+        it('should handle errors without a supplied default message', async () => {
+            const error = new Error();
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === 'Something went wrong, please try again or contact support');
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+
+        it('should handle errors with a status property', async () => {
+            const errorMessage = 'Not found';
+            const error = new Error();
+            error.status = 404;
+            error.message = errorMessage;
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === errorMessage);
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+
+        it('should handle errors with a 422 status', async () => {
+            const errorDetails = 'Details why the entity was unprocessable';
+            const error = new Error();
+            error.status = 422;
+            error.details = [errorDetails];
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === errorDetails);
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+
+        it('should handle errors with a 500 status', async () => {
+            const error = new Error();
+            error.status = 500;
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === 'Something went wrong on our servers, please contact support.');
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+
+        it('should handle RebillyConflictErrors', async () => {
+            const errorMessage = 'Useful error message';
+            const error = new Error();
+            error.name = 'RebillyConflictError';
+            error.message = errorMessage;
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === errorMessage);
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+
+        it('should ignore RebillyCanceledErrors', async () => {
+            const error = new Error();
+            error.name = 'RebillyCanceledError';
+            localVue.$toast.fromError(error);
+            const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+                /* eslint-disable no-underscore-dangle */
+                .map(toast => toast.__vue__)
+                .some(toast => toast._props && toast._props.message === 'Something went wrong, please try again or contact support');
+                /* eslint-enable no-underscore-dangle */
+
+            expect(hasToastAppeared).toBe(true);
+        });
+    });
+
 });

--- a/packages/recomponents/src/components/r-toast/r-toast.spec.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.spec.js
@@ -55,4 +55,17 @@ describe('r-toast.vue', () => {
 
         expect(managerToasts).toHaveLength(4);
     });
+
+    it('should create toasts from errors via toast-manager', async () => {
+        const error = new Error();
+        const toastMessage = 'Custom error text';
+        localVue.$toast.fromError(error, toastMessage);
+        const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
+            /* eslint-disable no-underscore-dangle */
+            .map(toast => toast.__vue__)
+            .some(toast => toast._props && toast._props.message === toastMessage);
+            /* eslint-enable no-underscore-dangle */
+
+        expect(hasToastAppeared).toBe(true);
+    });
 });

--- a/packages/recomponents/src/components/r-toast/r-toast.spec.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.spec.js
@@ -12,6 +12,7 @@ describe('r-toast.vue', () => {
     };
     const localVue = createLocalVue();
     localVue.use(RToastPlugin);
+    const createToastFromError = (...args) => localVue.$toast.fromError(...args);
 
     it('should render Wrapper and match snapshot', async () => {
         // const wrapper = localVue.$toast.positive(props.message, {autoHide: false});
@@ -59,7 +60,7 @@ describe('r-toast.vue', () => {
     it('should create toasts from errors via toast-manager', async () => {
         const error = new Error();
         const toastMessage = 'Custom error text';
-        localVue.$toast.fromError(error, toastMessage);
+        createToastFromError(error, toastMessage);
         const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
             /* eslint-disable no-underscore-dangle */
             .map(toast => toast.__vue__)
@@ -72,7 +73,7 @@ describe('r-toast.vue', () => {
     describe('r-toast-manager default error handling', () => {
         it('should handle errors without a supplied default message', async () => {
             const error = new Error();
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)
@@ -87,7 +88,7 @@ describe('r-toast.vue', () => {
             const error = new Error();
             error.status = 404;
             error.message = errorMessage;
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)
@@ -102,7 +103,7 @@ describe('r-toast.vue', () => {
             const error = new Error();
             error.status = 422;
             error.details = [errorDetails];
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)
@@ -115,7 +116,7 @@ describe('r-toast.vue', () => {
         it('should handle errors with a 500 status', async () => {
             const error = new Error();
             error.status = 500;
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)
@@ -130,7 +131,7 @@ describe('r-toast.vue', () => {
             const error = new Error();
             error.name = 'RebillyConflictError';
             error.message = errorMessage;
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)
@@ -143,7 +144,7 @@ describe('r-toast.vue', () => {
         it('should ignore RebillyCanceledErrors', async () => {
             const error = new Error();
             error.name = 'RebillyCanceledError';
-            localVue.$toast.fromError(error);
+            createToastFromError(error);
             const hasToastAppeared = [...document.getElementsByClassName(`r-toast`)]
                 /* eslint-disable no-underscore-dangle */
                 .map(toast => toast.__vue__)

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -10,10 +10,11 @@ import * as components from './components';
 import * as directives from './directives';
 
 function install(Vue, options = {}) {
+    const {ErrorHandler} = options;
+
     /**
      * Set global settings
      */
-
     Vue.$recomponents = {};
 
     Vue.$recomponents.settings = {
@@ -21,7 +22,7 @@ function install(Vue, options = {}) {
         ...options,
     };
 
-    Vue.use(RToastManager);
+    Vue.use(RToastManager, {ErrorHandler});
 
     /**
      * Injecting all components according to their filenames

--- a/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
+++ b/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
@@ -1,5 +1,6 @@
 import RToast from '../../components/r-toast/r-toast.vue';
 import RToastTypes from './r-toast-types';
+import DefaultErrorHandler from '../../common/helpers/default-error-handler';
 
 const ToastContainer = (Vue, globalOptions = {}) => ({
     show(options) {
@@ -42,6 +43,12 @@ const ToastContainer = (Vue, globalOptions = {}) => ({
             message,
             type: RToastTypes.Warning,
         }, options));
+    },
+    fromError(error, defaultMsg, params = {}) {
+        const errorHandler = globalOptions.ErrorHandler
+            ? globalOptions.ErrorHandler : DefaultErrorHandler;
+        const errors = errorHandler.parseError(error, defaultMsg);
+        errors.forEach(err => this.negative(err, params));
     },
 });
 


### PR DESCRIPTION
Adding new `fromError()` method on `r-toast-manager.js`.
This method has the option to either use the `DefaultErrorHandler` or a custom error handler passed via the plugin options of Recomponents.
