### PR TITLE
fix(directive): Fix position of tooltip for block elements

### DIFF
--- a/packages/recomponents/src/directives/r-tooltip/r-tooltip.js
+++ b/packages/recomponents/src/directives/r-tooltip/r-tooltip.js
@@ -20,7 +20,7 @@ export default {
                 const out = {};
                 out.top = tooltip.style.top.replace('px', '') < boundaryTop;
                 out.left = tooltip.style.left.replace('px', '') < boundaryLeft;
-                out.right = (elToCheck.right + (tooltipEl.width / 2))
+                out.right = (parseFloat(tooltip.style.left.replace('px', '')) + tooltipEl.width)
                     > (window.innerWidth || document.documentElement.clientWidth);
                 return out;
             };

--- a/packages/recomponents/src/directives/r-tooltip/r-tooltip.story.js
+++ b/packages/recomponents/src/directives/r-tooltip/r-tooltip.story.js
@@ -16,10 +16,8 @@ storiesOf('Directives', module)
                 <div>
                     <r-button type="primary" v-tooltip="{text: text}">With button</r-button>
                     <r-badge type="info" v-tooltip="{text: text}">With badge</r-badge>
-                    <!-- TODO tooltip usage -->
-                    <r-radio label="With radio"/>
-                    <!-- TODO tooltip usage -->
-                    <r-checkbox label="With checkbox"/>
+                    <r-radio label="With radio" v-tooltip="{text: text}"/>
+                    <r-checkbox label="With checkbox" v-tooltip="{text: text}"/>
                 </div>
                 <div>
                     <r-img src="https://www.rebilly.com/wp-content/uploads/2019/01/new_features@2x-319x150.png" v-tooltip="{text: text}"/>


### PR DESCRIPTION
### What was a problem?

Tooltip layout is incorrect for elements with full-page width:

![example](https://image.prntscr.com/image/pLV8v3NNT8WwoVbdPIyxMQ.png)

### How this PR fixes the problem?

Update of isOut.right calculation is enough.

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions