### PR TITLE
chore(r-toast): expose RToastManager and improve naming

### DIFF
--- a/packages/recomponents/src/components/r-toast/r-toast.spec.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.spec.js
@@ -154,5 +154,4 @@ describe('r-toast.vue', () => {
             expect(hasToastAppeared).toBe(true);
         });
     });
-
 });

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -4,7 +4,7 @@ import './styles/helpers.scss';
 import './styles/theme.scss';
 
 import kebabCase from './common/helpers/kebab-case';
-import RToastManager from './plugins/r-toast-manager';
+import RToastPlugin, {RToastManager} from './plugins/r-toast-manager';
 
 import * as components from './components';
 import * as directives from './directives';
@@ -22,7 +22,7 @@ function install(Vue, options = {}) {
         ...options,
     };
 
-    Vue.use(RToastManager, {ErrorHandler});
+    Vue.use(RToastPlugin, {ErrorHandler});
 
     /**
      * Injecting all components according to their filenames
@@ -46,4 +46,5 @@ export default {
     install,
     ...directives,
     ...components,
+    RToastManager,
 };

--- a/packages/recomponents/src/plugins/r-toast-manager/index.js
+++ b/packages/recomponents/src/plugins/r-toast-manager/index.js
@@ -1,13 +1,13 @@
 import RToast from '../../components/r-toast/r-toast.vue';
 import RToastManager from './r-toast-manager';
 
-const RToastPlugin = (Vue, options = {}) => {
+const RToastPlugin = RToast;
+
+RToastPlugin.install = (Vue, options = {}) => {
     const methods = RToastManager(Vue, options);
     Vue.$toast = methods;
     Vue.prototype.$toast = methods;
 };
 
-RToast.install = RToastPlugin;
-
 export {RToastManager};
-export default RToast;
+export default RToastPlugin;

--- a/packages/recomponents/src/plugins/r-toast-manager/index.js
+++ b/packages/recomponents/src/plugins/r-toast-manager/index.js
@@ -9,4 +9,5 @@ const RToastPlugin = (Vue, options = {}) => {
 
 RToast.install = RToastPlugin;
 
+export {RToastManager};
 export default RToast;

--- a/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
+++ b/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
@@ -2,7 +2,7 @@ import RToast from '../../components/r-toast/r-toast.vue';
 import RToastTypes from './r-toast-types';
 import DefaultErrorHandler from '../../common/helpers/default-error-handler';
 
-const ToastManager = (Vue, globalOptions = {}) => ({
+const RToastManager = (Vue, globalOptions = {}) => ({
     show(options) {
         let message;
         if (typeof options === 'string') {
@@ -52,4 +52,4 @@ const ToastManager = (Vue, globalOptions = {}) => ({
     },
 });
 
-export default ToastManager;
+export default RToastManager;

--- a/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
+++ b/packages/recomponents/src/plugins/r-toast-manager/r-toast-manager.js
@@ -2,7 +2,7 @@ import RToast from '../../components/r-toast/r-toast.vue';
 import RToastTypes from './r-toast-types';
 import DefaultErrorHandler from '../../common/helpers/default-error-handler';
 
-const ToastContainer = (Vue, globalOptions = {}) => ({
+const ToastManager = (Vue, globalOptions = {}) => ({
     show(options) {
         let message;
         if (typeof options === 'string') {
@@ -52,4 +52,4 @@ const ToastContainer = (Vue, globalOptions = {}) => ({
     },
 });
 
-export default ToastContainer;
+export default ToastManager;


### PR DESCRIPTION
* Expose `RToastManager` for use outside the `Recomponents` plugin
* Improve naming