### PR TITLE
chore(storybook): Add 2 stories for Vuelidate

### DIFF
--- a/packages/recomponents/package.json
+++ b/packages/recomponents/package.json
@@ -122,7 +122,8 @@
     "vue-no-ssr": "^1.1.1",
     "vue-router": "^3.1.2",
     "vue-server-renderer": "^2.6.10",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "vuelidate": "^0.7.5"
   },
   "peerDependencies": {
     "vue": "^2.6.0"

--- a/packages/recomponents/src/components/r-input/r-input.story.js
+++ b/packages/recomponents/src/components/r-input/r-input.story.js
@@ -1,6 +1,8 @@
 import {storiesOf} from '@storybook/vue';
 import {action} from '@storybook/addon-actions';
 import {text, select, boolean} from '@storybook/addon-knobs';
+import {validationMixin} from 'vuelidate';
+import {required} from 'vuelidate/lib/validators';
 import markdown from './r-input.md';
 import RInput from './r-input.vue';
 
@@ -145,6 +147,39 @@ storiesOf('Components.Input', module)
         },
         data: () => ({
             model: 'value here',
+        }),
+    }), {
+        notes: {markdown},
+    })
+    .add('Validation', () => ({
+        template: `
+            <div class="storybook-center">
+                <r-input
+                    v-model="model"
+                    :label="label"
+                    placeholder="Placeholder"
+                    :validate="$v.model"
+                    @input="input"
+                    />
+            </div>
+        `,
+        methods: {
+            input() {
+                action('input');
+            },
+        },
+        mixins: [validationMixin],
+        validations: {
+            model: {required},
+        },
+        computed: {
+            label() {
+                return `This field is required: ${this.$v.$invalid ? 'invalid' : 'valid'}`;
+            },
+        },
+        data: () => ({
+            model: 'Edit me',
+
         }),
     }), {
         notes: {markdown},

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -4,6 +4,8 @@ import {
     array, boolean, number, select, text,
 } from '@storybook/addon-knobs';
 import axios from 'axios';
+import {validationMixin} from 'vuelidate';
+import {required, helpers} from 'vuelidate/lib/validators';
 import markdown from './r-select.md';
 import RSelect from './r-select.vue';
 
@@ -132,7 +134,7 @@ storiesOf('Components.Select', module)
         },
         template: `
             <div class="storybook-center">
-                <div style="width: 50%;">
+                <div style="width: 300px;">
                     <p>Selected: {{ value }}</p>
                     <r-select
                         v-model="value"
@@ -308,7 +310,7 @@ storiesOf('Components.Select', module)
         },
         template: `
             <div class="storybook-center">
-                <div style="width: 50%;">
+                <div style="width: 300px;">
                     <p>Selected: {{ value }}</p>
                     <r-select
                         v-model="value"
@@ -472,7 +474,7 @@ storiesOf('Components.Select', module)
         },
         template: `
             <div class="storybook-center">
-                <div style="width: 50%;">
+                <div style="width: 300px;">
                     <p>Selected: {{ value }}</p>
                     <r-select
                         v-model="value"
@@ -509,6 +511,73 @@ storiesOf('Components.Select', module)
                         @open="open"
                         @remove="remove"
                         @search-change="searchChange"
+                        @select="select"
+                        @tag="tag"/>
+                </div>
+            </div>
+        `,
+    }), {
+        notes: {markdown},
+    })
+    .add('Validation', () => ({
+        data() {
+            return {
+                value: [],
+                options: [{
+                    label: 'Cat',
+                    value: 'cat',
+                }, {
+                    label: 'Doge',
+                    value: 'doge',
+                }, {
+                    label: 'Hamster',
+                    value: 'hamster',
+                }, {
+                    label: 'Chair',
+                    value: 'chair',
+                }],
+            };
+        },
+        props: {
+            multiple: {
+                default: boolean('Multiple', true),
+            },
+            tagPlaceholder: {
+                default: text('Tag placeholder', 'Press enter to create a tag'),
+            },
+            tagPosition: {
+                default: select('Tag position', {top: 'top', bottom: 'bottom'}, 'top'),
+            },
+            taggable: {
+                default: boolean('Taggable', true),
+            },
+        },
+        methods: {
+            select: action('select'),
+            tag: action('tag'),
+        },
+        computed: {
+            label() {
+                return `Select only pets: ${this.$v.$invalid ? 'invalid' : 'valid'}`;
+            },
+        },
+        mixins: [validationMixin],
+        validations: {
+            value: {
+                required,
+                pet: helpers.regex('alpha', /(cat|hamster|doge)/),
+            },
+        },
+        template: `
+            <div class="storybook-center">
+                <div style="width: 300px;">
+                    <p>Selected: {{ value }}</p>
+                    <r-select
+                        v-model="value"
+                        :label="label"
+                        :taggable="true"
+                        :options="options"
+                        :validate="$v.value"
                         @select="select"
                         @tag="tag"/>
                 </div>

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -539,9 +539,6 @@ storiesOf('Components.Select', module)
             };
         },
         props: {
-            multiple: {
-                default: boolean('Multiple', true),
-            },
             tagPlaceholder: {
                 default: text('Tag placeholder', 'Press enter to create a tag'),
             },

--- a/packages/recomponents/yarn.lock
+++ b/packages/recomponents/yarn.lock
@@ -21326,6 +21326,11 @@ vue@^2.5.0, vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuelidate@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.7.5.tgz#ff48c75ae9d24ea24c24e9ea08065eda0a0cba0a"
+  integrity sha512-GAAG8QAFVp7BFeQlNaThpTbimq3+HypBPNwdkCkHZZeVaD5zmXXfhp357dcUJXHXTZjSln0PvP6wiwLZXkFTwg==
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
### What was a problem?

In https://github.com/Rebilly/rebilly-recomponents/pull/145/ proposed to create separate prop for tag validator in RSelect component. I'd like to propose use only Vuelidate outside of select component.

### How this PR fixes the problem?

Added two stories how to use Vuelidate with Recomponents

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions