### PR TITLE
feat(component): Add render function support for RToast

### DIFF
--- a/packages/recomponents/src/components/r-toast/__snapshots__/r-toast.spec.js.snap
+++ b/packages/recomponents/src/components/r-toast/__snapshots__/r-toast.spec.js.snap
@@ -6,7 +6,9 @@ exports[`r-toast.vue should render Wrapper and match snapshot 1`] = `
   <div class="r-toast-close">
     <!---->
   </div>
-  <!---->
+  <div data-cy="Toast Message" class="r-toast-message">
+    <!---->
+  </div>
 </div>
 `;
 
@@ -15,6 +17,7 @@ exports[`r-toast.vue should render via SSR and match snapshot 1`] = `
   <!---->
   <div class="r-toast-close">
     <!---->
-  </div> <span data-cy="Toast Message" class="r-toast-message">test toast</span>
+  </div>
+  <div data-cy="Toast Message" class="r-toast-message"><span data-cy="Toast Message" class="r-toast-message">test toast</span></div>
 </div>
 `;

--- a/packages/recomponents/src/components/r-toast/r-toast.story.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.story.js
@@ -108,4 +108,24 @@ storiesOf('Components.Toast', module)
         },
     }), {
         notes: {markdown},
+    })
+    .add('Render function', () => ({
+        template: `
+            <div>
+                <div class="storybook-center">
+                    <div class="r-grid">
+                        <div class="r-grid-item">
+                            <r-button type="default" @click="renderFunction">Render function</r-button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `,
+        methods: {
+            renderFunction() {
+                this.$toast.warning(createElement => createElement('h1', 'H1 Toast Content'));
+            },
+        },
+    }), {
+        notes: {markdown},
     });

--- a/packages/recomponents/src/components/r-toast/r-toast.vue
+++ b/packages/recomponents/src/components/r-toast/r-toast.vue
@@ -109,8 +109,8 @@
                 if (typeof this.message === 'function') {
                     return {
                         render: this.message,
-                        props: this.$options.props
-                    }
+                        props: this.$options.props,
+                    };
                 }
 
                 return null;

--- a/packages/recomponents/src/components/r-toast/r-toast.vue
+++ b/packages/recomponents/src/components/r-toast/r-toast.vue
@@ -14,7 +14,10 @@
                     color="text"
                     icon="close-s"/>
         </div>
-        <span class="r-toast-message" data-cy="Toast Message" v-if="message">{{message}}</span>
+        <div class="r-toast-message" data-cy="Toast Message">
+            <component v-if="markup" :is="markup"/>
+            <span class="r-toast-message" data-cy="Toast Message" v-else-if="message">{{message}}</span>
+        </div>
     </div>
 </template>
 <script>
@@ -38,7 +41,7 @@
              * Change the toast message
              */
             message: {
-                type: String,
+                type: [String, Function],
             },
             /**
              * Specify if the user is allowed to close the toast
@@ -101,6 +104,16 @@
                     'is-visible': this.isVisible,
                     [`r-toast-${this.type}`]: true,
                 };
+            },
+            markup() {
+                if (typeof this.message === 'function') {
+                    return {
+                        render: this.message,
+                        props: this.$options.props
+                    }
+                }
+
+                return null;
             },
         },
         methods: {


### PR DESCRIPTION
### What was a problem?

* We removed all entries of v-html in Recomponents because of security reason, but we need the way to style toast messages.

### How this PR fixes the problem?

* Added support of render function as RToast child content

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions

### Additional Comments (if any)

{Please write here}