### PR TITLE
fix(r-pagination): Double requests on pagination init

### DIFF
--- a/packages/recomponents/src/components/r-pagination/r-pagination.story.js
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.story.js
@@ -55,7 +55,7 @@ storiesOf('Components.Pagination', module)
                 <h2>Page #5</h2>
                 <r-pagination
                     :provider="provider"
-                    :total="100"
+                    :total="10"
                     :totalVisible="1"
                     :limit="1"
                     v-model="pagination2"
@@ -63,7 +63,7 @@ storiesOf('Components.Pagination', module)
                 <h2>Page #10</h2>
                 <r-pagination
                     :provider="provider"
-                    :total="100"
+                    :total="10"
                     :totalVisible="1"
                     :limit="1"
                     v-model="pagination3"

--- a/packages/recomponents/src/components/r-pagination/r-pagination.vue
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.vue
@@ -171,11 +171,17 @@
             pagination() {
                 return {
                     hasPagination: this.hasPagination,
-                    provider: this.provider(this.page),
+                    provider: () => this.provider(this.page),
                     offset: this.page,
                     items: this.items,
                 };
             },
+        },
+        mounted() {
+            this.provider(this.page);
+        },
+        created() {
+            this.$on('navigate', page => this.provider(page));
         },
     };
 </script>


### PR DESCRIPTION

### What was a problem?

* We had unexpected list provider call when the computed property was changed

### How this PR fixes the problem?

* AJAX request in computed property calculation is a bad approach, remove it is enough to fix this issue. 

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions
