### PR TITLE
chore(storybook): Create shared validation mock for knobs

### DIFF
--- a/packages/recomponents/.storybook/knobs.js
+++ b/packages/recomponents/.storybook/knobs.js
@@ -110,3 +110,24 @@ export const colors = {
     'text': 'text',
     'yellow': 'yellow',
 };
+
+/**
+ * Validation wrapper for stories without Vuelidate
+ */
+export const validate = {
+    valid: {
+        $dirty: false,
+        $invalid: false,
+        $touch: () => {}
+    },
+    dirty: {
+        $dirty: true,
+        $invalid: false,
+        $touch: () => {}
+    },
+    invalid: {
+        $dirty: true,
+        $invalid: true,
+        $touch: () => {}
+    },
+}

--- a/packages/recomponents/src/components/r-input/r-input.story.js
+++ b/packages/recomponents/src/components/r-input/r-input.story.js
@@ -5,6 +5,7 @@ import {validationMixin} from 'vuelidate';
 import {required} from 'vuelidate/lib/validators';
 import markdown from './r-input.md';
 import RInput from './r-input.vue';
+import {validate} from '../../../.storybook/knobs';
 
 storiesOf('Components.Input', module)
     .addParameters({component: RInput})
@@ -62,23 +63,7 @@ storiesOf('Components.Input', module)
                 default: boolean('disabled', false, 'State'),
             },
             validate: {
-                default: select('validate', {
-                    valid: {
-                        $dirty: false,
-                        $invalid: false,
-                    },
-                    dirty: {
-                        $dirty: true,
-                        $invalid: false,
-                    },
-                    invalid: {
-                        $dirty: true,
-                        $invalid: true,
-                    },
-                }, {
-                    $dirty: false,
-                    $invalid: false,
-                }, 'State'),
+                default: select('validate', validate, null, 'State'),
             },
             placeholder: {
                 default: text('placeholder', 'Please input value here', 'Text'),

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -8,6 +8,7 @@ import {validationMixin} from 'vuelidate';
 import {required, helpers} from 'vuelidate/lib/validators';
 import markdown from './r-select.md';
 import RSelect from './r-select.vue';
+import {validate} from '../../../.storybook/knobs';
 
 storiesOf('Components.Select', module)
     .addParameters({component: RSelect})
@@ -31,23 +32,7 @@ storiesOf('Components.Select', module)
                 default: boolean('Disabled', false, 'State'),
             },
             validate: {
-                default: select('validate', {
-                    valid: {
-                        $dirty: false,
-                        $invalid: false,
-                    },
-                    dirty: {
-                        $dirty: true,
-                        $invalid: false,
-                    },
-                    invalid: {
-                        $dirty: true,
-                        $invalid: true,
-                    },
-                }, {
-                    $dirty: false,
-                    $invalid: false,
-                }, 'State'),
+                default: select('validate', validate, null, 'State'),
             },
             helpText: {
                 default: text('Help Text', 'Help text for select', 'Text'),
@@ -195,23 +180,7 @@ storiesOf('Components.Select', module)
                 default: boolean('Close on select', true),
             },
             validate: {
-                default: select('validate', {
-                    valid: {
-                        $dirty: false,
-                        $invalid: false,
-                    },
-                    dirty: {
-                        $dirty: true,
-                        $invalid: false,
-                    },
-                    invalid: {
-                        $dirty: true,
-                        $invalid: true,
-                    },
-                }, {
-                    $dirty: false,
-                    $invalid: false,
-                }),
+                default: select('validate', validate, null, 'State'),
             },
             disabled: {
                 default: boolean('Disabled', false),


### PR DESCRIPTION
### What was a problem?

* Go to https://recomponents.rebilly.com/?path=/story/components-select--component
* Observer error `this.validate.$touch is not a function`

### How this PR fixes the problem?

* Created shared knob for all components that require validation in stories

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions