### PR TITLE
fix(r-pagination): wrong quantity of visible buttons

### DIFF
--- a/packages/recomponents/src/components/r-pagination-control/r-pagination-control.vue
+++ b/packages/recomponents/src/components/r-pagination-control/r-pagination-control.vue
@@ -11,15 +11,15 @@
                     <template v-for="(item, index) in override.items">
                         <span class="r-pagination-control-button"
                               :key="index"
-                              v-if="isNaN(item)">
-                            {{ item }}
+                              v-if="item.breakView">
+                            ...
                         </span>
                         <r-button v-else
                                   :key="index"
-                                  @click="override.page(item)"
+                                  @click="override.page(item.content)"
                                   class="r-pagination-control-button"
-                                  :class="{'r-button-type-primary': isActive(item)}">
-                            {{ item }}
+                                  :class="{'r-button-type-primary': item.selected}">
+                            {{ item.content }}
                         </r-button>
                     </template>
                     <r-button class="r-pagination-control-button" @click="override.next" :disabled="!override.hasNext">
@@ -81,11 +81,6 @@
                     hasNext: this.hasNext,
                     hasPrevious: this.hasPrevious,
                 };
-            },
-        },
-        methods: {
-            isActive(page) {
-                return this.offset === page;
             },
         },
     };

--- a/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
+++ b/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
@@ -15,9 +15,7 @@ exports[`r-pagination.vue should render via SSR and match snapshot 1`] = `
             <use xlink:href="#icon-arrow-left" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
           </svg>
           Prev
-        </button> <span class="r-pagination-control-button">
-                        ...
-                    </span> <button role="button" title="" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
+        </button> <button role="button" title="" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
           <!---->
           Next
           <svg class="r-icon r-icon-20">

--- a/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
+++ b/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
@@ -15,7 +15,9 @@ exports[`r-pagination.vue should render via SSR and match snapshot 1`] = `
             <use xlink:href="#icon-arrow-left" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
           </svg>
           Prev
-        </button> <button role="button" title="" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
+        </button> <span class="r-pagination-control-button">
+                        ...
+                    </span> <button role="button" title="" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
           <!---->
           Next
           <svg class="r-icon r-icon-20">

--- a/packages/recomponents/src/components/r-pagination/r-pagination.spec.js
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.spec.js
@@ -122,10 +122,11 @@ describe('r-pagination.vue', () => {
             },
         });
 
-        expect(wrapper.vm.items).toEqual([1, 2, '...', 9, 10]);
-        wrapper.setData({page: 8});
-        expect(wrapper.vm.items).toEqual([1, '...', 7, 8, 9, '...', 10]);
+        const getVisible = (items) => Object.values(items).map(({content}) => content);
+        expect(getVisible(wrapper.vm.items)).toEqual([1, 2, 3, 4, 5, undefined]);
+        wrapper.setData({page: 5});
+        expect(getVisible(wrapper.vm.items)).toEqual([undefined, 3, 4, 5, 6, 7, undefined]);
         wrapper.setData({page: 10});
-        expect(wrapper.vm.items).toEqual([1, 2, '...', 9, 10]);
+        expect(getVisible(wrapper.vm.items)).toEqual([undefined, 6, 7, 8, 9, 10]);
     });
 });

--- a/packages/recomponents/src/components/r-pagination/r-pagination.spec.js
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.spec.js
@@ -122,11 +122,13 @@ describe('r-pagination.vue', () => {
             },
         });
 
-        const getVisible = (items) => Object.values(items).map(({content}) => content);
+        const getVisible = items => Object.values(items).map(({content}) => content);
         expect(getVisible(wrapper.vm.items)).toEqual([1, 2, 3, 4, 5, undefined]);
         wrapper.setData({page: 5});
         expect(getVisible(wrapper.vm.items)).toEqual([undefined, 3, 4, 5, 6, 7, undefined]);
         wrapper.setData({page: 10});
         expect(getVisible(wrapper.vm.items)).toEqual([undefined, 6, 7, 8, 9, 10]);
+        wrapper.setData({totalVisible: 0});
+        expect(getVisible(wrapper.vm.items)).toEqual([]);
     });
 });

--- a/packages/recomponents/src/components/r-pagination/r-pagination.vue
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.vue
@@ -93,32 +93,24 @@
         },
         computed: {
             items() {
-                let items = {};
+                const items = {};
+                const setPageItem = (index) => {
+                    const page = {
+                        content: index + 1,
+                        selected: index === (this.page - 1),
+                    };
+                    items[index] = page;
+                };
+
                 if (this.pages <= this.totalVisible) {
-                    for (let index = 0; index < this.pages; index++) {
-                        let page = {
-                            index: index,
-                            content: index + 1,
-                            selected: index === (this.page - 1),
-                        };
-                        items[index] = page;
+                    for (let index = 0; index < this.pages; index += 1) {
+                        setPageItem(index);
                     }
                 } else {
                     const half = Math.floor(this.totalVisible / 2);
 
-                    const setPageItem = index => {
-                        let page = {
-                            index: index,
-                            content: index + 1,
-                            selected: index === (this.page - 1),
-                        };
-                        items[index] = page;
-                    };
-                    const setBreakView = index => {
-                        let breakView = {
-                            disabled: true,
-                            breakView: true,
-                        };
+                    const setBreakView = (index) => {
+                        const breakView = {breakView: true};
                         items[index] = breakView;
                     };
 
@@ -133,16 +125,20 @@
                         left = right - this.totalVisible + 1;
                     }
 
-                    for (let i = left; i <= right && i <= this.pages - 1; i++) {
+                    for (let i = left; i <= right && i <= this.pages - 1; i += 1) {
                         setPageItem(i);
                     }
-                    if (left > 0) {
-                        setBreakView(left - 1);
+
+                    if (this.totalVisible > 0) {
+                        if (left > 0) {
+                            setBreakView(left - 1);
+                        }
+                        if (right + 1 < this.pages) {
+                            setBreakView(right + 1);
+                        }
                     }
-                    if (right + 1 < this.pages) {
-                        setBreakView(right + 1);
-                    }
-                    for (let i = this.pages - 1; i >= this.pages; i--) {
+
+                    for (let i = this.pages - 1; i >= this.pages; i -= 1) {
                         setPageItem(i);
                     }
                 }

--- a/packages/recomponents/src/components/r-pagination/r-pagination.vue
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.vue
@@ -77,16 +77,6 @@
                  */
                 this.$emit('navigate', number);
             },
-            range(start, end) {
-                const range = [];
-
-                start = start > 0 ? start : 1;
-                for (let i = start; i <= end; i += 1) {
-                    range.push(i);
-                }
-
-                return range;
-            },
         },
         provide() {
             return {
@@ -103,54 +93,60 @@
         },
         computed: {
             items() {
-                const {totalVisible} = this;
+                let items = {};
+                if (this.pages <= this.totalVisible) {
+                    for (let index = 0; index < this.pages; index++) {
+                        let page = {
+                            index: index,
+                            content: index + 1,
+                            selected: index === (this.page - 1),
+                        };
+                        items[index] = page;
+                    }
+                } else {
+                    const half = Math.floor(this.totalVisible / 2);
 
-                if (!totalVisible) {
-                    return null;
-                }
+                    const setPageItem = index => {
+                        let page = {
+                            index: index,
+                            content: index + 1,
+                            selected: index === (this.page - 1),
+                        };
+                        items[index] = page;
+                    };
+                    const setBreakView = index => {
+                        let breakView = {
+                            disabled: true,
+                            breakView: true,
+                        };
+                        items[index] = breakView;
+                    };
 
-                if (this.pages <= totalVisible || totalVisible < 1) {
-                    return this.range(1, this.pages);
-                }
-
-                const even = totalVisible % 2 === 0 ? 1 : 0;
-                const left = Math.floor(totalVisible / 2);
-                const right = this.pages - left + 1 + even;
-
-                if (this.page > left && this.page < right) {
-                    const start = this.page - left + 1;
-                    const end = this.page + left - 1 - even;
-
-                    if (totalVisible === 1 || totalVisible === 2) {
-                        const items = [];
-                        if (totalVisible === 2) {
-                            items.push(1);
-                        }
-                        if (this.page !== 1 && (this.page !== 2 && totalVisible === 2)) {
-                            items.push('...');
-                        }
-                        items.push(this.page);
-                        if (this.page !== this.pages) {
-                            items.push('...');
-                        }
-                        return items;
+                    let left = 0;
+                    if (this.page - half > 0) {
+                        left = this.page - 1 - half;
                     }
 
-                    return [1, '...', ...this.range(start, end), '...', this.pages];
+                    let right = left + this.totalVisible - 1;
+                    if (right >= this.pages) {
+                        right = this.pages - 1;
+                        left = right - this.totalVisible + 1;
+                    }
+
+                    for (let i = left; i <= right && i <= this.pages - 1; i++) {
+                        setPageItem(i);
+                    }
+                    if (left > 0) {
+                        setBreakView(left - 1);
+                    }
+                    if (right + 1 < this.pages) {
+                        setBreakView(right + 1);
+                    }
+                    for (let i = this.pages - 1; i >= this.pages; i--) {
+                        setPageItem(i);
+                    }
                 }
-                if (this.page === left) {
-                    const end = this.page + left - 1 - even;
-                    return end < 1 ? [...this.range(1, this.page), '...'] : [...this.range(1, end), '...', this.pages];
-                }
-                if (this.page === right) {
-                    const start = this.page - left + 1;
-                    return [1, '...', ...this.range(start, this.pages)];
-                }
-                return [
-                    ...this.range(1, left),
-                    '...',
-                    ...this.range(right, this.pages),
-                ];
+                return items;
             },
             pages() {
                 let pages = Math.ceil(this.total / this.limit);


### PR DESCRIPTION
### What was a problem?
There is a knobb with visible page navigation buttons, it doesn't work properly. 

How it was: [video](https://jira.ilabsinc.com/secure/attachment/19384/19384_Screen+Recording+2020-01-23+at+04.21.39.mov)

Now:
![](https://media.giphy.com/media/jPNU4r1GMNhP8JW8jw/giphy.gif)