### PR TITLE
fix(r-popper): fix view of more than 16 options in popper menu

### DIFF
--- a/packages/recomponents/src/components/r-popper/r-popper.scss
+++ b/packages/recomponents/src/components/r-popper/r-popper.scss
@@ -165,6 +165,14 @@
 
 .r-popover-content.r-popover-menu {
     padding: var(--popover-content-menu-padding);
+    overflow: scroll;
+    max-height: inherit;
+    background: var(--popover-background);
+    min-width: var(--popover-min-width);
+    background: var(--popover-background);
+    box-shadow: var(--popover-box-shadow);
+    border-radius: var(--popover-border-radius);
+    transition: var(--popover-transition);
 }
 
 .r-popover-action-menu-item,

--- a/packages/recomponents/src/components/r-popper/r-popper.story.js
+++ b/packages/recomponents/src/components/r-popper/r-popper.story.js
@@ -14,6 +14,7 @@ storiesOf('Components.Popper', module)
             openOnMount: {default: boolean('Open on mount', false)},
             disabled: {default: boolean('Disabled', false)},
             offset: {default: number('Offset', 4)},
+            quantityOfOptions: {default: number('Quantity of options', 2)},
             direction: {
                 default: select('Direction', {
                     Horizontal: 'horizontal',
@@ -81,11 +82,8 @@ storiesOf('Components.Popper', module)
                         <div class="r-popover">
                             <div class="r-popover-control">
                                 <div class="r-popover-content r-popover-menu">
-                                    <a class="r-popover-menu-item">
-                                        Edit
-                                    </a>
-                                    <a class="r-popover-menu-item r-popover-menu-item-negative">
-                                        Remove
+                                    <a class="r-popover-menu-item" v-for="i in quantityOfOptions">
+                                        Option #{{ i }}
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
### What was a problem?
Small change for fixing the view of r-popper when there are more than 16 options (one line options)

![](https://i.imgur.com/uN0XUR3.png)