### PR TITLE
Keep the same style as in the recomm

### DIFF
--- a/packages/recomponents/src/styles/theme.scss
+++ b/packages/recomponents/src/styles/theme.scss
@@ -430,7 +430,7 @@ body, .article {
     --tab-link-error-color: var(--negative-color);
     --tab-link-error-border-bottom-color: var(--negative-color);
     --tab-link-first-margin-left: var(--space-m);
-    --tab-content-padding: 0 20px 20px 20px;
+    --tab-content-padding: 20px;
     --tab-content-tile-padding: var(--space-m) 0;
 
     // Toggle


### PR DESCRIPTION
### What was a problem?

The style of .r-tab-content is not the same with .tab-content so the UI is not that right

### How this PR fixes the problem?

Before
![image](https://user-images.githubusercontent.com/4344909/74321373-1bdf5400-4dbd-11ea-98e8-015c6cfeead2.png)

After
![image](https://user-images.githubusercontent.com/4344909/74321393-26015280-4dbd-11ea-9d2c-5016275b5704.png)

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions
