### PR TITLE
fix(r-date-range): small changes and fixies for report integration

### DIFF
--- a/packages/recomponents/src/components/r-date-range/r-date-range.story.js
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.story.js
@@ -47,10 +47,14 @@ storiesOf('Components.Date Range', module)
         },
         methods: {
             convertDate(date) {
-                return this.$tz().fromDate(date).format(DateTimeFormats.datePickerDate);
+                return this.$tz().fromDate(date).format(DateTimeFormats.shortDate);
             },
             updatePeriod(period) {
-                this.period = `${this.convertDate(period.start)}..${this.convertDate(period.end)}`;
+                this.period = {
+                    ...period,
+                    start: this.convertDate(period.start),
+                    end: this.convertDate(period.end),
+                };
             },
         },
         template: `

--- a/packages/recomponents/src/components/r-date-range/r-date-range.vue
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.vue
@@ -83,7 +83,7 @@
              * Specify the selected period
              */
             period: {
-                type: String,
+                type: [String, Object],
                 required: true,
             },
             /**
@@ -158,7 +158,7 @@
                     return null;
                 }
                 const preset = this.calendarPresetsPeriodsList
-                    .find(([, {relativeFilterValue}]) => relativeFilterValue === this.period);
+                    .find(([, {relativeFilterValue}]) => relativeFilterValue === this.period.relativeFilterValue);
                 if (preset) {
                     // the period value is one of default relative presets
                     const [presetName, presetParams] = preset;
@@ -168,12 +168,8 @@
                         ...presetParams,
                     };
                 }
-                // the props period value is relative but not default preset
-                const [start, end] = this.period.split('..');
-                // this is the relative value but not value from the preset
-                // so the value could be like "5 years ago..now"
-                // see https://help.rebilly.com/en/articles/3296639-relative-time-filters
-                return {start, end};
+
+                return this.parsePeriod(this.period);
             },
             isRelativePreset() {
                 // returns true if the props period is relative date and one of default presets
@@ -188,7 +184,7 @@
                         end: relative.end,
                     };
                 }
-                const [start, end] = this.period.split('..');
+                const {start, end} = this.parsePeriod(this.period);
                 if (this.isValidDatesPeriod) {
                     // the start and end values are ISO strings
                     // convert to profile timezone
@@ -278,6 +274,13 @@
                 }
 
                 this.$refs.calendar.popper.close();
+            },
+            parsePeriod(period) {
+                if (typeof this.period === 'string') {
+                    const [start, end] = this.period.split('..');
+                    return {start, end};
+                }
+                return period;
             },
             relativeFilterChange(presetName) {
                 const period = this.calendarPresetsPeriods[presetName];

--- a/packages/recomponents/src/components/r-grid/r-grid.md
+++ b/packages/recomponents/src/components/r-grid/r-grid.md
@@ -5,10 +5,11 @@ The `r-grid` component is designed to power the rendering of any tabular data an
 ### Props
 
 
-| prop         | type             | default value | description                                                             |
-|--------------|------------------|---------------|-------------------------------------------------------------------------|
-| columns*     | `Object`         |               | Enumerates columns to be rendered with type specific configuration info |
-| provider*    | `Function`       |               | Returns some data to be rendered by the default scopped slot            |
+| prop               | type               | default value   | description                                                               |
+|--------------------|--------------------|-----------------| --------------------------------------------------------------------------|
+| columns*           | `Object`           |                 | Enumerates columns to be rendered with type specific configuration info   |
+| provider*          | `Function`         |                 | Returns some data to be rendered by the default scopped slot              |
+| isLoaderFullscreen | `boolean`          | `true`          | Defines if the loading state is fullscreen                                |
 
 ### Slots
 

--- a/packages/recomponents/src/components/r-grid/r-grid.md
+++ b/packages/recomponents/src/components/r-grid/r-grid.md
@@ -2,15 +2,6 @@
 
 The `r-grid` component is designed to power the rendering of any tabular data and features configurable columns and automatic column formatting via colum types.
 
-### Props
-
-
-| prop               | type               | default value   | description                                                               |
-|--------------------|--------------------|-----------------| --------------------------------------------------------------------------|
-| columns*           | `Object`           |                 | Enumerates columns to be rendered with type specific configuration info   |
-| provider*          | `Function`         |                 | Returns some data to be rendered by the default scopped slot              |
-| isLoaderFullscreen | `boolean`          | `true`          | Defines if the loading state is fullscreen                                |
-
 ### Slots
 
 This component has 5 optional slots:

--- a/packages/recomponents/src/components/r-grid/r-grid.story.js
+++ b/packages/recomponents/src/components/r-grid/r-grid.story.js
@@ -6,9 +6,9 @@ storiesOf('Components/Grid', module)
     .addParameters({component: RGrid})
     .add('Grid', () => ({
         template: `
-            <r-pagination :provider="provider" :limit="limit" :total="total">
+            <r-pagination :provider="provider" :limit="limit" :total="total" @navigate="setPage" :page="page">
                 <template #pagination="{pagination}">
-                    <r-grid :provider="pagination.provider" :columns="columns" :key="pagination.offset">
+                    <r-grid :provider="provider(pagination.offset)" :columns="columns" :key="pagination.offset">
                         <header slot="header">
                             <h1 class="r-mb-l">Numbers</h1>
                         </header>
@@ -53,6 +53,7 @@ storiesOf('Components/Grid', module)
                 },
                 limit: 3,
                 total: 9,
+                page: 1,
             };
         },
         methods: {
@@ -98,6 +99,9 @@ storiesOf('Components/Grid', module)
                 }
 
                 return [];
+            },
+            setPage(page) {
+                this.page = page;
             },
         },
     }), {

--- a/packages/recomponents/src/components/r-grid/r-grid.vue
+++ b/packages/recomponents/src/components/r-grid/r-grid.vue
@@ -11,9 +11,14 @@
                 type: Object,
                 required: true,
             },
+            watcher: {},
             provider: {
                 type: [Function, Array, Promise],
                 required: true,
+            },
+            isLoaderFullscreen: {
+                type: Boolean,
+                default: true,
             },
         },
         computed: {
@@ -146,6 +151,8 @@
                     class: 'r-grid-repeater',
                     props: {
                         provider: this.computedProvider,
+                        watcher: {},
+                        isLoaderFullscreen: this.isLoaderFullscreen,
                     },
                     scopedSlots: {
                         default: prop => this.renderRepeaterRow(createElement, prop),

--- a/packages/recomponents/src/components/r-grid/r-grid.vue
+++ b/packages/recomponents/src/components/r-grid/r-grid.vue
@@ -7,15 +7,27 @@
             Repeater,
         },
         props: {
+            /**
+             * Specify the columns
+             */
             columns: {
                 type: Object,
                 required: true,
             },
+            /**
+             * Defines the property, which changes will trigger the fetching of data
+             */
             watcher: {},
+            /**
+             * Returns some data to be rendered by the default scoped slot
+             */
             provider: {
                 type: [Function, Array, Promise],
                 required: true,
             },
+            /**
+             * Defines if the loading state is fullscreen
+             */
             isLoaderFullscreen: {
                 type: Boolean,
                 default: true,

--- a/packages/recomponents/src/components/r-repeater/r-repeater.md
+++ b/packages/recomponents/src/components/r-repeater/r-repeater.md
@@ -2,24 +2,6 @@
 
 This is an abstract component to help you render tabular data. It is notably used by `r-grid` under the hood.
 
-### Props
-
-
-| prop               | type               | default value   | description                                                    |
-|---------------     | ------------------ | --------------- | ---------------------------------------------------------------|
-| provider*          | function           |                 | Returns some data to be rendered by the default scopped slot   |
-| isLoaderFullscreen | boolean            | `true`          | Defines if the loading state is fullscreen                     |
-
-### Slots
-
-This component has 4 optional slots and a required default slot:
-
-* `default` **required** for content that belongs in a `<tr>`
-* `colgroup` **optional** for colgroups - see HTML `<colgroup>`
-* `thead` **optional** for thead - see HTML `<thead>`
-* `headers` **optional** to just specify the `<th>`s of your table, rather than the whole `thead`
-* `empty` **optional** for empty states (if the provider function returns no data)
-
 ### Usage
 
 #### CommonJS module

--- a/packages/recomponents/src/components/r-repeater/r-repeater.md
+++ b/packages/recomponents/src/components/r-repeater/r-repeater.md
@@ -5,9 +5,10 @@ This is an abstract component to help you render tabular data. It is notably use
 ### Props
 
 
-| prop         | type             | default value | description                                                  |
-|--------------|------------------|---------------|--------------------------------------------------------------|
-| provider*    | function         |               | Returns some data to be rendered by the default scopped slot |
+| prop               | type               | default value   | description                                                    |
+|---------------     | ------------------ | --------------- | ---------------------------------------------------------------|
+| provider*          | function           |                 | Returns some data to be rendered by the default scopped slot   |
+| isLoaderFullscreen | boolean            | `true`          | Defines if the loading state is fullscreen                     |
 
 ### Slots
 

--- a/packages/recomponents/src/components/r-repeater/r-repeater.vue
+++ b/packages/recomponents/src/components/r-repeater/r-repeater.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="r-table-control flex-center">
-        <r-loader v-if="isLoading"/>
+        <r-loader v-if="isLoading" :fullscreen="isLoaderFullscreen"></r-loader>
         <template v-else>
             <table class="r-table" v-if="hasRows">
                 <slot name="colgroup"/>
@@ -34,6 +34,11 @@
                 type: Function,
                 required: true,
             },
+            isLoaderFullscreen: {
+                type: Boolean,
+                default: true,
+            },
+            watcher: {},
         },
         data() {
             return {
@@ -60,6 +65,11 @@
         },
         created() {
             this.fetchData();
+        },
+        watch: {
+            watcher() {
+                this.fetchData();
+            },
         },
     };
 </script>

--- a/packages/recomponents/src/components/r-repeater/r-repeater.vue
+++ b/packages/recomponents/src/components/r-repeater/r-repeater.vue
@@ -3,20 +3,25 @@
         <r-loader v-if="isLoading" :fullscreen="isLoaderFullscreen"></r-loader>
         <template v-else>
             <table class="r-table" v-if="hasRows">
+                <!-- @slot for colgroups - see HTML \<colgroup> -->
                 <slot name="colgroup"/>
+                <!-- @slot for thead - see HTML \<thead> -->
                 <slot name="thead">
                     <thead>
                     <tr>
+                        <!-- @slot to just specify the \<th> of your table, rather than the whole thead -->
                         <slot name="headers"/>
                     </tr>
                     </thead>
                 </slot>
                 <tbody>
                 <template v-for="(item, itemIdx) in rows">
+                    <!-- @slot for content that belongs in a \<tr> -->
                     <slot :item="item" :index="itemIdx"/>
                 </template>
                 </tbody>
             </table>
+            <!-- @slot for empty states (if the provider function returns no data) -->
             <slot name="empty" v-else></slot>
         </template>
     </div>
@@ -30,14 +35,23 @@
             RLoader,
         },
         props: {
+            /**
+             * Returns some data to be rendered by the default scoped slot
+             */
             provider: {
                 type: Function,
                 required: true,
             },
+            /**
+             * Defines if the loading state is fullscreen
+             */
             isLoaderFullscreen: {
                 type: Boolean,
                 default: true,
             },
+            /**
+             * Defines the property, which changes will trigger the fetching of data
+             */
             watcher: {},
         },
         data() {


### PR DESCRIPTION
### What was a problem?

`RGrid` has a fullscreen loader by default - that's not the common case. Added the property to be able to define it. And fixed the story.
`RDateRange` is not supporting the period as an object.

### Check lists

- [x] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions