### PR TITLE
fix(component): Fix RButtonGroup items in Safari

### DIFF
--- a/packages/recomponents/src/components/r-button-group/r-button-group.scss
+++ b/packages/recomponents/src/components/r-button-group/r-button-group.scss
@@ -11,6 +11,8 @@
 .r-button-group .r-button {
     margin-left: -1px;
     margin-left: -0.1rem;
+    margin-right: -1px;
+    margin-right: -0.1rem;
 }
 
 .r-button-group .r-button:not(:first-child):not(:last-child),


### PR DESCRIPTION
### What was a problem?

Gap between RButtonGroup buttons only in Safari.

### How this PR fixes the problem?

Additional negative margin did the trick, was not related to font-size or letter spacing.

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions