### PR TITLE
feat(r-grid): support international format for numeric grid type

### DIFF
--- a/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
+++ b/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
@@ -21,6 +21,7 @@ export default ({createElement, props}) => {
                 currency,
                 percentage,
                 digits,
+                internationalFormat,
             } = {},
         },
     } = props;
@@ -32,11 +33,16 @@ export default ({createElement, props}) => {
             hasDigits = true;
         }
 
+        const intl = global.Intl;
+
         if (approximate) {
             displayValue = approximateNumber(value);
+        } else if (internationalFormat) {
+            displayValue = intl ? new intl.NumberFormat().format(value) : value;
         } else if (currency) {
-            const intl = global.Intl || {NumberFormat: () => ({})};
-            displayValue = new intl.NumberFormat('en-US', {style: 'currency', currency}).format(value);
+            displayValue = intl
+                ? new intl.NumberFormat(undefined, {style: 'currency', currency}).format(value)
+                : `${value} ${currency}`;
         } else if (percentage) {
             if (percentage === true) {
                 if (hasDigits) {

--- a/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
+++ b/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
@@ -36,11 +36,11 @@ export default ({createElement, props}) => {
         if (approximate) {
             displayValue = approximateNumber(value);
         } else if (internationalFormat) {
-            displayValue = typeof Intl === 'undefined' ? value : new Intl.NumberFormat().format(value);
+            displayValue = typeof Intl !== 'undefined' ? new Intl.NumberFormat().format(value) : value;
         } else if (currency) {
-            displayValue = typeof Intl === 'undefined'
-                ? `${value} ${currency}`
-                : new Intl.NumberFormat(undefined, {style: 'currency', currency}).format(value);
+            displayValue = typeof Intl !== 'undefined'
+                ? new Intl.NumberFormat(undefined, {style: 'currency', currency}).format(value)
+                : `${value} ${currency}`;
         } else if (percentage) {
             if (percentage === true) {
                 if (hasDigits) {

--- a/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
+++ b/packages/recomponents/src/components/r-grid/columnTypes/numeric.js
@@ -33,16 +33,14 @@ export default ({createElement, props}) => {
             hasDigits = true;
         }
 
-        const intl = global.Intl;
-
         if (approximate) {
             displayValue = approximateNumber(value);
         } else if (internationalFormat) {
-            displayValue = intl ? new intl.NumberFormat().format(value) : value;
+            displayValue = typeof Intl === 'undefined' ? value : new Intl.NumberFormat().format(value);
         } else if (currency) {
-            displayValue = intl
-                ? new intl.NumberFormat(undefined, {style: 'currency', currency}).format(value)
-                : `${value} ${currency}`;
+            displayValue = typeof Intl === 'undefined'
+                ? `${value} ${currency}`
+                : new Intl.NumberFormat(undefined, {style: 'currency', currency}).format(value);
         } else if (percentage) {
             if (percentage === true) {
                 if (hasDigits) {

--- a/packages/recomponents/src/components/r-grid/r-grid.story.js
+++ b/packages/recomponents/src/components/r-grid/r-grid.story.js
@@ -37,6 +37,12 @@ storiesOf('Components/Grid', module)
                                 textAlign: 'center',
                             },
                             renderAs: 'text',
+                        }, {
+                            name: 'money',
+                            renderAs: 'numeric',
+                            renderOptions: {
+                                currency: 'USD',
+                            },
                         },
                         {
                             name: 'type',
@@ -61,13 +67,13 @@ storiesOf('Components/Grid', module)
                 if (page === 1) {
                     return [
                         {
-                            id: 1, name: 'One', type: 'Odd', updatedAt: '12/25/2019',
+                            id: 1, name: 'One', type: 'Odd', money: 4734, updatedAt: '12/25/2019',
                         },
                         {
-                            id: 2, name: 'Two', type: ['Even', 'Prime'], updatedAt: '12/25/2019',
+                            id: 2, name: 'Two', type: ['Even', 'Prime'], money: 23, updatedAt: '12/25/2019',
                         },
                         {
-                            id: 3, name: 'Three', type: ['Odd', 'Prime'], updatedAt: '12/25/2019',
+                            id: 3, name: 'Three', type: ['Odd', 'Prime'], money: 436478326, updatedAt: '12/25/2019',
                         },
                     ];
                 }


### PR DESCRIPTION
### What was a problem?
The grid with the type `numeric` should support international formatting

![](https://i.imgur.com/EFDqgYN.png)
![](https://i.imgur.com/lFRBioj.png)