### PR TITLE
chore(component): add for attribute to labels in r-input and r-select

### DIFF
--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="r-field" :class="{'r-is-error': isInvalid}">
-        <label v-if="label" class="r-field-label">{{label}}</label>
+        <label v-if="label" :for="name" class="r-field-label">{{label}}</label>
         <template v-if="!isGroupedInput">
             <input
                     ref="input"
+                    :id="name"
                     v-if="!multiline"
                     class="r-field-input"
                     v-fs-block
@@ -23,6 +24,7 @@
                     :autocomplete="autocompleteFlag"/>
             <textarea
                     ref="textarea"
+                    :id="name"
                     v-else-if="multiline && submitOnEnter"
                     class="r-field-input"
                     v-fs-block
@@ -39,6 +41,7 @@
             </textarea>
             <textarea
                     ref="textarea"
+                    :id="name"
                     v-else="multiline && !submitOnEnter"
                     class="r-field-input"
                     v-fs-block
@@ -64,6 +67,7 @@
                         @click.stop="$emit('left-icon-click')"></r-icon>
                 <input
                         ref="input"
+                        :id="name"
                         class="r-field-input"
                         v-fs-block
                         :value="value"

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -1,6 +1,5 @@
 <template>
     <div :class="classes" v-fs-block>
-        TOCINO
         <label v-if="hasLabel"
                :for="id"
                @click="activate"

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -1,6 +1,8 @@
 <template>
     <div :class="classes" v-fs-block>
+        TOCINO
         <label v-if="hasLabel"
+               :for="id"
                @click="activate"
                class="r-field-label">{{label}}
         </label>


### PR DESCRIPTION
### What was a problem?

A label for a form control helps everyone better understand its purpose. When using labels we need to bind the `for` attribute to the internal form control.

### How this PR fixes the problem?

- Adds label for attribute pointing to the related internal input in all the possible variants of `<r-input>` component 
- Adds label for attribute pointing to the related internal input in all the possible variants of `<r-select>` component 
