### PR TITLE
Pass close option to RToastManager

### DIFF
--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -11,7 +11,7 @@ import * as components from './components';
 import * as directives from './directives';
 
 function install(Vue, options = {}) {
-    const {ErrorHandler} = options;
+    const {ErrorHandler, allowClose} = options;
 
     /**
      * Set global settings
@@ -23,7 +23,7 @@ function install(Vue, options = {}) {
         ...options,
     };
 
-    Vue.use(RToastPlugin, {ErrorHandler});
+    Vue.use(RToastPlugin, {ErrorHandler, allowClose});
 
     Vue.component('no-ssr', NoSSR);
 


### PR DESCRIPTION
### What was a problem?

RToast components are not closable in Recomm. RToast support ability to close by it self, but we cannot enable this feature during `Vue.use(Recomponents)` installation.

### How this PR fixes the problem?

* Pass option to RToastManager from global options

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions
