### PR TITLE
Update closable / non-closable RToasts

### DIFF
--- a/packages/recomponents/README.md
+++ b/packages/recomponents/README.md
@@ -49,6 +49,15 @@ Or bundled with webpack:
 </script>
 ```
 
+During installation you can specify some options that could ovverride default behaviour of some components.
+
+<details>
+  <summary>List of available options</summary>
+
+  * `ErrorHandler` - [Handler](https://github.com/Rebilly/rebilly-recomponents/blob/master/packages/recomponents/src/common/helpers/default-error-handler.js) to convert any server / client error into user-friendly message that can be displayed via RToast
+  * `allowToastCloseButton` - Add ability to close all RToast messages by default
+</details>
+
 ## Documentation
 
 We prefer [Storybook](https://storybook.js.org/) to plain-old documentation. [Check it out](https://recomponents.rebilly.com/) to see all of our components on display, with a comprehensive description and the ability to tweak properties and slots.

--- a/packages/recomponents/src/components/r-toast/r-toast.md
+++ b/packages/recomponents/src/components/r-toast/r-toast.md
@@ -1,2 +1,15 @@
 `RToast` component is used to show quick messages to user.  Appears temporarily in the top right zone of the screen.
 To manage multiple toasters at the same time using RToasterManager plugin that is installed by default with Recomponents bundle.
+
+Default Recomponents [installation](https://github.com/Rebilly/rebilly-recomponents/tree/master/packages/recomponents#usage) provide `RToastManager` plugin that is available in Vue scope, so you can display any possible toast with $toast
+
+```js
+this.$toast.positive('Something positive in your code');
+```
+
+You can override default closable settings by providing special option:
+
+```js
+this.$toast.info('Closable toast', {allowClose: true});
+this.$toast.info('Non-closable toast', {allowClose: true});
+```

--- a/packages/recomponents/src/components/r-toast/r-toast.story.js
+++ b/packages/recomponents/src/components/r-toast/r-toast.story.js
@@ -90,10 +90,16 @@ storiesOf('Components.Toast', module)
                 <div class="storybook-center">
                     <div class="r-grid">
                         <div class="r-grid-item">
-                            <r-button type="default" @click="addToast('positive')">Positive</r-button>
-                            <r-button type="default" @click="addToast('negative')">Negative</r-button>
-                            <r-button type="default" @click="addToast('warning')">Warning</r-button>
-                            <r-button type="default" @click="addToast('info')">Info</r-button>
+                            <r-button type="default" @click="addDefaultToast('positive')">Default Positive</r-button>
+                            <r-button type="default" @click="addDefaultToast('negative')">Default Negative</r-button>
+                            <r-button type="default" @click="addDefaultToast('warning')">Default Warning</r-button>
+                            <r-button type="default" @click="addDefaultToast('info')">Default Info</r-button>
+                        </div>
+                        <div class="r-grid-item">
+                            <r-button type="default" @click="addClosableToast('positive')">Closable Positive</r-button>
+                            <r-button type="default" @click="addClosableToast('negative')">Closable Negative</r-button>
+                            <r-button type="default" @click="addClosableToast('warning')">Closable Warning</r-button>
+                            <r-button type="default" @click="addClosableToast('info')">Closable Info</r-button>
                         </div>
                     </div>
                 </div>
@@ -101,8 +107,11 @@ storiesOf('Components.Toast', module)
         `,
         props: {},
         methods: {
-            addToast(type) {
-                this.$toast[type](`Test ${type} toast :)`);
+            addDefaultToast(type) {
+                this.$toast[type](`Test ${type} toast`, {allowClose: false});
+            },
+            addClosableToast(type) {
+                this.$toast[type](`Close ${type} toast`, {allowClose: true});
             },
             hide: action('hide'),
         },

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -11,7 +11,7 @@ import * as components from './components';
 import * as directives from './directives';
 
 function install(Vue, options = {}) {
-    const {ErrorHandler, allowClose} = options;
+    const {ErrorHandler, allowToastCloseButton} = options;
 
     /**
      * Set global settings
@@ -23,7 +23,10 @@ function install(Vue, options = {}) {
         ...options,
     };
 
-    Vue.use(RToastPlugin, {ErrorHandler, allowClose});
+    Vue.use(RToastPlugin, {
+        ErrorHandler,
+        allowClose: allowToastCloseButton,
+    });
 
     Vue.component('no-ssr', NoSSR);
 


### PR DESCRIPTION
### What was a problem?

* Name of option for toasts was to generic
* Not clear how to override closable / non-closable behaviour

### How this PR fixes the problem?

* Documentation update with examples
* Option rename

### Check lists

- [x] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions
