### PR TITLE
feat(header-actions): Add header actions slot to r-modal

### DIFF
--- a/packages/recomponents/src/components/r-modal/r-modal.md
+++ b/packages/recomponents/src/components/r-modal/r-modal.md
@@ -6,6 +6,7 @@
 | `left-actions`    | left action buttons                          |
 | `right-actions`   | right action buttons                         |
 | `actions`         | action buttons after default cancel button   |
+| `header-actions`  | action buttons before close button in header |
 
 
 ### Events

--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -17,7 +17,13 @@
                      @mousedown="$event.stopPropagation()">
                     <div v-if="title" class="r-modal-header">
                         <h2>{{title}}</h2>
-                        <r-button type="link" class="r-modal-btn-close" @click="$emit('close')" aria-label="close">
+                        <slot name="header-actions"/>
+                        <r-button 
+                            type="link" 
+                            class="r-modal-btn-close"
+                            :class="{'r-ml-s': $slots['header-actions']}"
+                            @click="$emit('close')" 
+                            aria-label="close">
                             <r-icon icon="close"/>
                         </r-button>
                     </div>

--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -17,11 +17,12 @@
                      @mousedown="$event.stopPropagation()">
                     <div v-if="title" class="r-modal-header">
                         <h2>{{title}}</h2>
-                        <slot name="header-actions"/>
+                        <div class="margin-left-auto inline-s">
+                            <slot name="header-actions"/>
+                        </div>
                         <r-button 
                             type="link" 
                             class="r-modal-btn-close"
-                            :class="{'r-ml-s': $slots['header-actions']}"
                             @click="$emit('close')" 
                             aria-label="close">
                             <r-icon icon="close"/>

--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -20,10 +20,10 @@
                         <div class="margin-left-auto inline-s">
                             <slot name="header-actions"/>
                         </div>
-                        <r-button 
-                            type="link" 
+                        <r-button
+                            type="link"
                             class="r-modal-btn-close"
-                            @click="$emit('close')" 
+                            @click="$emit('close')"
                             aria-label="close">
                             <r-icon icon="close"/>
                         </r-button>


### PR DESCRIPTION
### What was a problem?

We want to add an action to the modal header, as in this RFC:
https://product.rebilly.dev/priorities/kyc/0000-kyc-workbench-ux/#basic-example

### How this PR fixes the problem?

This PR adds a new slot to the left of the close button

### Check lists

- [x] Readme file updated with actual description and example