### PR TITLE
fix(modal-title): Fix text transform

### DIFF
--- a/packages/recomponents/src/components/r-modal/r-modal.scss
+++ b/packages/recomponents/src/components/r-modal/r-modal.scss
@@ -84,7 +84,6 @@
 
 .r-modal-header h2 {
     margin: 0;
-    text-transform: capitalize;
 }
 
 .r-modal-header .r-button > .r-icon {


### PR DESCRIPTION
### What was a problem?

Header modal title shouldn't override the title original string.

### How this PR fixes the problem?

Removed CSS `text-transform: capitalize` rule.