### PR TITLE
Hot fix for width of r-grid with frozen column

### DIFF
--- a/packages/recomponents/src/components/r-grid/r-grid.scss
+++ b/packages/recomponents/src/components/r-grid/r-grid.scss
@@ -15,6 +15,7 @@
 .r-repeater-with-frozen-column {
     overflow-x: scroll;
     min-width: 400px;
+    width: 100%;
     padding-left: 245px !important;
 
     th {


### PR DESCRIPTION
### What was a problem?
Forgot to set the width of `r-grid`.
There was set only the `min-width`.