### PR TITLE
Make buttons with capitalized text accesible

### DIFF
--- a/packages/recomponents/src/components/r-button/__snapshots__/r-button.spec.js.snap
+++ b/packages/recomponents/src/components/r-button/__snapshots__/r-button.spec.js.snap
@@ -3,6 +3,6 @@
 exports[`r-button.vue should render via SSR and match snapshot 1`] = `
 <button role="button" title="" msg="Apply" class="r-button r-button-size-regular r-button-type-default">
   <!---->
-  <div class="r-capitalize-first-letter">Apply</div>
+  <div role="button" class="r-capitalize-first-letter">Apply</div>
 </button>
 `;

--- a/packages/recomponents/src/components/r-button/r-button.vue
+++ b/packages/recomponents/src/components/r-button/r-button.vue
@@ -8,7 +8,7 @@
        :target="$attrs.href ? '_target' : $attrs.target || ''"
     >
         <!-- @slot Text content inside button  -->
-        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter">
+        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter" role="button">
             <slot>Link</slot>
         </div>
         <slot v-else>Apply</slot>
@@ -22,7 +22,7 @@
             :title="title"
     >
         <r-icon v-if="loading" icon="loading" class="r-is-spinning r-icon-light-gray r-inline-s"/>
-        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter">
+        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter" role="button">
             <slot>Apply</slot>
         </div>
         <slot v-else>Apply</slot>

--- a/packages/recomponents/src/components/r-date-range/__snapshots__/r-date-range.spec.js.snap
+++ b/packages/recomponents/src/components/r-date-range/__snapshots__/r-date-range.spec.js.snap
@@ -5,12 +5,12 @@ exports[`r-date-range.vue renders props when passed 1`] = `
   <div role="group" class="r-button-group"><button class="r-button r-button-type-default r-button-size-regular r-has-icon-left"><svg class="r-icon r-icon-20 r-date-range-calendar-icon">
         <use xlink:href="#icon-calendar" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
       </svg>
-      <div class="r-capitalize-first-letter"><span title="America/Montreal" class="r-date-range-label">
+      <div role="button" class="r-capitalize-first-letter button"><span title="America/Montreal" class="r-date-range-label">
                     Dec 31, 2019 - Jan 1, 2020
                 </span> </div>
     </button>
     <div class="r-popper r-date-range-preset-picker"><button class="r-button r-button-type-default r-button-size-regular r-has-icon">
-        <div class="r-capitalize-first-letter"><svg class="r-icon r-icon-20">
+        <div role="button" class="r-capitalize-first-letter button"><svg class="r-icon r-icon-20">
             <use xlink:href="#icon-actions" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
           </svg></div>
       </button>

--- a/packages/recomponents/src/components/r-icon-button/__snapshots__/r-icon-button.spec.js.snap
+++ b/packages/recomponents/src/components/r-icon-button/__snapshots__/r-icon-button.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`r-icon-button.vue should render via SSR and match snapshot 1`] = `
 <button class="r-button r-button-type-default r-button-size-regular r-has-icon">
-  <div class="r-capitalize-first-letter">Apply</div>
+  <div role="button" class="r-capitalize-first-letter button">Apply</div>
 </button>
 `;

--- a/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
+++ b/packages/recomponents/src/components/r-icon-button/r-icon-button.vue
@@ -6,7 +6,7 @@
         :disabled="disabled"
         v-tooltip="{text: tooltip}">
         <slot name="left-icon"></slot>
-        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter">
+        <div v-if="capitalizeFirstLetter" class="r-capitalize-first-letter button" role="button">
             <slot>Apply</slot>
         </div>
         <slot v-else>Apply</slot>

--- a/packages/recomponents/src/components/r-pagination-control/__snapshots__/r-pagination-control.spec.js.snap
+++ b/packages/recomponents/src/components/r-pagination-control/__snapshots__/r-pagination-control.spec.js.snap
@@ -22,14 +22,14 @@ exports[`r-pagination-control.vue should render via SSR and match snapshot 1`] =
   <div class="r-pagination-control">
     <div class="r-pagination-control-buttons-wrapper"><button role="button" disabled="disabled" title="Action is disabled" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
         <!---->
-        <div class="r-capitalize-first-letter"><svg class="r-icon r-icon-20">
+        <div role="button" class="r-capitalize-first-letter"><svg class="r-icon r-icon-20">
             <use xlink:href="#icon-arrow-left" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
           </svg>
           Prev
         </div>
       </button> <button role="button" disabled="disabled" title="Action is disabled" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
         <!---->
-        <div class="r-capitalize-first-letter">
+        <div role="button" class="r-capitalize-first-letter">
           Next
           <svg class="r-icon r-icon-20">
             <use xlink:href="#icon-arrow-right" xmlns:xlink="http://www.w3.org/1999/xlink"></use>

--- a/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
+++ b/packages/recomponents/src/components/r-pagination/__snapshots__/r-pagination.spec.js.snap
@@ -12,14 +12,14 @@ exports[`r-pagination.vue should render via SSR and match snapshot 1`] = `
     <div class="r-pagination-control">
       <div class="r-pagination-control-buttons-wrapper"><button role="button" disabled="disabled" title="Action is disabled" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
           <!---->
-          <div class="r-capitalize-first-letter"><svg class="r-icon r-icon-20">
+          <div role="button" class="r-capitalize-first-letter"><svg class="r-icon r-icon-20">
               <use xlink:href="#icon-arrow-left" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
             </svg>
             Prev
           </div>
         </button> <button role="button" title="" class="r-button r-pagination-control-button r-button-size-regular r-button-type-default">
           <!---->
-          <div class="r-capitalize-first-letter">
+          <div role="button" class="r-capitalize-first-letter">
             Next
             <svg class="r-icon r-icon-20">
               <use xlink:href="#icon-arrow-right" xmlns:xlink="http://www.w3.org/1999/xlink"></use>

--- a/packages/recomponents/src/components/r-webcomponent/__snapshots__/r-webcomponent.spec.js.snap
+++ b/packages/recomponents/src/components/r-webcomponent/__snapshots__/r-webcomponent.spec.js.snap
@@ -5,7 +5,7 @@ exports[`r-webcomponent.vue should render Wrapper and match snapshot 1`] = `<div
 exports[`r-webcomponent.vue should render all specified components 1`] = `
 <div class="r-webcomponent"><button role="button" title="" class="r-button r-button-size-regular r-button-type-default">
     <!---->
-    <div class="r-capitalize-first-letter">Apply</div>
+    <div role="button" class="r-capitalize-first-letter">Apply</div>
   </button></div>
 `;
 


### PR DESCRIPTION
### What was a problem?

Buttons containing a `<div> slot` (used to add capitalize class) were not accesible (Empty [accesible name](https://www.w3.org/TR/accname-1.1/)).

### How this PR fixes the problem?

Adding a[ button role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role) makes the button accesible. 

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

### Additional Comments 

This also allows these buttons to be more testable by tools like testing library that uses [role to query UI elements](https://testing-library.com/docs/dom-testing-library/api-queries#byrole). 