### PR TITLE
fix(r-grid): make numeric columns formatted and hide scrollbars

### DIFF
--- a/packages/recomponents/src/components/r-grid/r-grid.scss
+++ b/packages/recomponents/src/components/r-grid/r-grid.scss
@@ -5,15 +5,20 @@
 }
 
 .r-grid-body {
-    overflow: scroll
+    overflow: auto;
 }
 
 .r-repeater-cell-badge {
     padding: var(--space-xs) !important;
 }
 
+.r-repeater-cell-numeric {
+    font-family: var(--code-font-stack);
+    text-align: right;
+}
+
 .r-repeater-with-frozen-column {
-    overflow-x: scroll;
+    overflow-x: auto;
     min-width: 400px;
     width: 100%;
     padding-left: 225px !important;


### PR DESCRIPTION
### What was a problem?
Numeric type columns are formatted by default (with special readable font and right-aligned).
![](https://i.imgur.com/TALQGqZ.png)