### PR TITLE
Add inheritAttrs:false to avoid attrs passed to inner input being duplicated in parent div (inside r-input)

### DIFF
--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -113,6 +113,7 @@
     // TODO classes prefix r-is-error, r-no-flex, etc.
     export default {
         name: 'RInput',
+        inheritAttrs: false,
         components: {rIcon},
         props: {
             /**


### PR DESCRIPTION


### What was a problem?

The custom attributes passed to `r-input` were duplicated between `parent div` and `child input`

### How this PR fixes the problem?

Setting [inheritAttrs](https://vuejs.org/v2/api/#inheritAttrs) to false avoids the root div to have duplicated attrs. 

### Check lists

- [ ] Readme file updated with actual description and example
- [ ] Added all ARIA attributes required for component
- [ ] Added tests for both browser and SSR render and for all components properties
- [ ] Added story with all knobs and actions

