### PR TITLE
fix(r-date-range): Fix relative periods and emit the periods as a string

### DIFF
--- a/packages/recomponents/src/components/r-date-range/r-date-range.vue
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.vue
@@ -163,7 +163,7 @@
             isRelative() {
                 // the props value period is relative period but could be custom period
                 // so it could be something like '5 years ago..now'
-                return !this.isValidDatesPeriod;
+                return this.period.isRelative || !this.isValidDatesPeriod;
             },
             selectedRelativeParams() {
                 // returns {start, end, presetName: (optional), presetLabel: (optional)}
@@ -304,6 +304,9 @@
             },
             relativeFilterChange(presetName) {
                 const period = this.calendarPresetsPeriods[presetName];
+                const start = this.timezoneHandler().getRaw(period.start);
+                const end = this.timezoneHandler().getRaw(period.end);
+
                 /**
                  * The date range selected
                  * @type {Event}
@@ -311,6 +314,8 @@
                 this.$emit('input', {
                     isRelative: true,
                     ...period,
+                    start,
+                    end,
                 });
                 this.$nextTick(() => {
                     this.close();


### PR DESCRIPTION
### What was a problem?
Keep the periods as a string (now there are strings for manual selection and moment for presets).
When loads if the selected period is relative it doesn't work properly.
