### PR TITLE
Fix relative periods for r-range-picker

### DIFF
--- a/packages/recomponents/src/components/r-date-range/r-date-range.spec.js
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.spec.js
@@ -75,10 +75,10 @@ describe('r-date-range.vue', () => {
         };
 
         wrapper.vm.dateChange(selected);
-        expect(wrapper.emitted().input[0][0].start.format(DateTimeFormats.datetime))
-            .toEqual(selected.start.format(DateTimeFormats.datetime));
-        expect(wrapper.emitted().input[0][0].end.format(DateTimeFormats.datetime))
-            .toEqual(selected.end.format(DateTimeFormats.datetime));
+        expect(wrapper.emitted().input[0][0].start)
+            .toEqual(selected.start.format());
+        expect(wrapper.emitted().input[0][0].end)
+            .toEqual(selected.end.format());
     });
 
     it('should toggle the poppers', async () => {
@@ -113,10 +113,10 @@ describe('r-date-range.vue', () => {
         expect(wrapper.vm.getFormattedPresetPeriod(preset))
             .toEqual(moment().format(DateTimeFormats.orderDate));
         wrapper.vm.relativeFilterChange(preset);
-        expect(wrapper.emitted().input[0][0].start.format(DateTimeFormats.datetime))
-            .toEqual(moment().startOf('day').format(DateTimeFormats.datetime));
-        expect(wrapper.emitted().input[0][0].end.format(DateTimeFormats.datetime))
-            .toEqual(moment().endOf('day').format(DateTimeFormats.datetime));
+        expect(wrapper.emitted().input[0][0].start)
+            .toEqual(moment().startOf('day').utc(true).format());
+        expect(wrapper.emitted().input[0][0].end)
+            .toEqual(moment().endOf('day').utc(true).format());
     });
 
     it('should show selected date range properly', async () => {

--- a/packages/recomponents/src/components/r-date-range/r-date-range.spec.js
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.spec.js
@@ -28,6 +28,11 @@ class TimezoneMock {
     }
 
     // eslint-disable-next-line class-methods-use-this
+    readLocalDate(date) {
+        return moment(date);
+    }
+
+    // eslint-disable-next-line class-methods-use-this
     getRaw(date) {
         return moment.tz(date, this.tz()).utc();
     }

--- a/packages/recomponents/src/components/r-date-range/r-date-range.vue
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.vue
@@ -304,8 +304,8 @@
             },
             relativeFilterChange(presetName) {
                 const period = this.calendarPresetsPeriods[presetName];
-                const start = this.timezoneHandler().getRaw(period.start);
-                const end = this.timezoneHandler().getRaw(period.end);
+                const start = period.start.format();
+                const end = period.end.format();
 
                 /**
                  * The date range selected
@@ -329,12 +329,12 @@
                 // the problem details: if your browser timezone is +3 then you will have .toISOString as 21:00
                 // and user profile timezone will never change that value
                 const start = this.minDate && this.checkDatesAreSame(this.minDate, date.start)
-                    ? this.timezoneHandler().getRaw(this.minDate)
-                    : this.timezoneHandler().getRaw(moment(date.start).startOf('day'));
+                    ? this.timezoneHandler().fromDate(this.minDate).format()
+                    : this.timezoneHandler().fromDate(moment(date.start).startOf('day')).format();
 
                 const end = this.maxDate && this.checkDatesAreSame(this.maxDate, date.end)
-                    ? this.timezoneHandler().getRaw(this.maxDate)
-                    : this.timezoneHandler().getRaw(moment(date.end).endOf('day'));
+                    ? this.timezoneHandler().fromDate(this.maxDate).format()
+                    : this.timezoneHandler().fromDate(moment(date.end).endOf('day')).format();
 
                 this.$emit('input', {
                     isRelative: false,

--- a/packages/recomponents/src/components/r-date-range/r-date-range.vue
+++ b/packages/recomponents/src/components/r-date-range/r-date-range.vue
@@ -202,10 +202,10 @@
                 const {start, end} = this.parsePeriod(this.period);
                 if (this.isValidDatesPeriod) {
                     // the start and end values are ISO strings
-                    // convert to profile timezone
+                    // read dates in profile selected timezone
                     return {
-                        start: this.timezoneHandler().fromDate(start),
-                        end: this.timezoneHandler().fromDate(end),
+                        start: this.timezoneHandler().readLocalDate(start),
+                        end: this.timezoneHandler().readLocalDate(end),
                     };
                 }
                 return {

--- a/packages/recomponents/src/components/r-month-picker/__snapshots__/r-month-picker-input.spec.js.snap
+++ b/packages/recomponents/src/components/r-month-picker/__snapshots__/r-month-picker-input.spec.js.snap
@@ -19,7 +19,7 @@ exports[`r-month-picker-input.vue should render via SSR and match snapshot 1`] =
 <div class="r-popper"><button class="r-button r-month-picker-input r-button-type-default r-button-size-regular r-has-icon-left"><svg class="r-icon r-icon-20 r-date-range-calendar-icon">
       <use xlink:href="#icon-calendar" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
     </svg>
-    <div role="button" class="r-capitalize-first-letter button"><span>August, 2020</span> </div>
+    <div role="button" class="r-capitalize-first-letter button"><span class="r-text-muted">Select month</span> </div>
   </button>
   <div class="r-popper-content-wrapper">
     <transition-stub name="fade">

--- a/packages/recomponents/src/components/r-month-picker/__snapshots__/r-month-picker.spec.js.snap
+++ b/packages/recomponents/src/components/r-month-picker/__snapshots__/r-month-picker.spec.js.snap
@@ -59,7 +59,7 @@ exports[`r-month-picker.vue should render via SSR and match snapshot 1`] = `
           <use xlink:href="#icon-caret-left" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
         </svg></div>
     </button>
-    <div>2020</div> <button class="r-button r-month-picker-year-right r-button-type-default r-button-size-small r-has-icon">
+    <div></div> <button class="r-button r-month-picker-year-right r-button-type-default r-button-size-small r-has-icon">
       <div role="button" class="r-capitalize-first-letter button"><svg class="r-icon r-icon-20">
           <use xlink:href="#icon-caret-right" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
         </svg></div>
@@ -87,7 +87,7 @@ exports[`r-month-picker.vue should render via SSR and match snapshot 1`] = `
     <div class="r-month-picker-month">
       July
     </div>
-    <div class="r-month-picker-month r-month-picker-month-selected">
+    <div class="r-month-picker-month">
       August
     </div>
     <div class="r-month-picker-month">

--- a/packages/recomponents/src/components/r-month-picker/month-picker-mixin.js
+++ b/packages/recomponents/src/components/r-month-picker/month-picker-mixin.js
@@ -11,7 +11,7 @@ export default {
          * Selected month and year
          */
         value: {
-            default: () => defaultValue,
+            defaultValue: () => defaultValue,
             required: true,
         },
         /**
@@ -26,7 +26,7 @@ export default {
     data() {
         return {
             months,
-            selectedDate: defaultValue,
+            selectedDate: null,
         };
     },
     computed: {

--- a/packages/recomponents/src/components/r-month-picker/month-picker-mixin.js
+++ b/packages/recomponents/src/components/r-month-picker/month-picker-mixin.js
@@ -11,7 +11,7 @@ export default {
          * Selected month and year
          */
         value: {
-            defaultValue: () => defaultValue,
+            default: () => defaultValue,
             required: true,
         },
         /**

--- a/packages/recomponents/src/components/r-month-picker/r-month-picker-input.spec.js
+++ b/packages/recomponents/src/components/r-month-picker/r-month-picker-input.spec.js
@@ -5,8 +5,12 @@ import RMonthPickerInput from './r-month-picker-input.vue';
 import RMonthPicker from './r-month-picker.vue';
 
 describe('r-month-picker-input.vue', () => {
-    it('should render Wrapper and match snapshot', () => {
-        const wrapper = shallowMount(RMonthPickerInput, {});
+    it('should render Wrapper and match snapshot', async () => {
+        const wrapper = await shallowMount(RMonthPickerInput, {
+            propsData: {
+                value: {monthIndex: 7, year: 2020},
+            },
+        });
         expect(wrapper).toMatchSnapshot();
     });
     it('should render via SSR and match snapshot', async () => {

--- a/packages/recomponents/src/components/r-month-picker/r-month-picker.spec.js
+++ b/packages/recomponents/src/components/r-month-picker/r-month-picker.spec.js
@@ -4,8 +4,12 @@ import RMonthPicker from './r-month-picker.vue';
 import RIconButton from '../r-icon-button/r-icon-button.vue';
 
 describe('r-month-picker.vue', () => {
-    it('should render Wrapper and match snapshot', () => {
-        const wrapper = shallowMount(RMonthPicker, {});
+    it('should render Wrapper and match snapshot', async () => {
+        const wrapper = await shallowMount(RMonthPicker, {
+            propsData: {
+                value: {monthIndex: 7, year: 2020},
+            },
+        });
         expect(wrapper).toMatchSnapshot();
     });
     it('should render via SSR and match snapshot', async () => {


### PR DESCRIPTION
### What was a problem?

The date range is processed twice, resulting in confusion with timezones.

### How this PR fixes the problem?

The date range picker returns the ready values of `start` and `end` in the timezone which was selected in the parent application.
