### PR TITLE
fix(r-select): fix calling asyncFind on search

### DIFF
--- a/packages/recomponents/src/components/r-select/r-select.spec.js
+++ b/packages/recomponents/src/components/r-select/r-select.spec.js
@@ -517,4 +517,24 @@ describe('r-select.vue', () => {
         wrapper.vm.removeLastElement();
         expect(wrapper.emitted().input).toEqual([[['1'], 'id']]);
     });
+
+    it('should search asynchronous based on keyword', async () => {
+        const asyncFind = () => [1, 2, 3];
+        const wrapper = shallowMount(RSelect, {
+            propsData: {
+                id: 'id',
+                value: [],
+                asyncFind,
+                asyncGetInitValue: () => [],
+            },
+        });
+        const spy = jest.spyOn(wrapper.vm, 'handleAsyncFind');
+
+        await Vue.nextTick();
+        expect(wrapper.vm.filteredOptions.length).toBe(3);
+
+        await wrapper.setData({search: 'acme'});
+        expect(wrapper.vm.handleAsyncFind).toHaveBeenCalledTimes(1)
+
+    });
 });

--- a/packages/recomponents/src/components/r-select/r-select.spec.js
+++ b/packages/recomponents/src/components/r-select/r-select.spec.js
@@ -520,21 +520,21 @@ describe('r-select.vue', () => {
 
     it('should search asynchronous based on keyword', async () => {
         const asyncFind = () => [1, 2, 3];
+        const asyncGetInitValue = () => [];
         const wrapper = shallowMount(RSelect, {
             propsData: {
                 id: 'id',
                 value: [],
                 asyncFind,
-                asyncGetInitValue: () => [],
+                asyncGetInitValue,
             },
         });
-        const spy = jest.spyOn(wrapper.vm, 'handleAsyncFind');
+        jest.spyOn(wrapper.vm, 'handleAsyncFind');
 
         await Vue.nextTick();
         expect(wrapper.vm.filteredOptions.length).toBe(3);
 
         await wrapper.setData({search: 'acme'});
-        expect(wrapper.vm.handleAsyncFind).toHaveBeenCalledTimes(1)
-
+        expect(wrapper.vm.handleAsyncFind).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -326,6 +326,7 @@ storiesOf('Components.Select', module)
     .add('Async data', () => ({
         data() {
             return {
+                options: [],
                 value: null,
             };
         },
@@ -357,6 +358,9 @@ storiesOf('Components.Select', module)
             limit: {
                 default: number('Limit', 4),
             },
+            loading: {
+                default: boolean('Loading', true),
+            },
             max: {
                 default: number('Max', 8),
             },
@@ -383,7 +387,6 @@ storiesOf('Components.Select', module)
             },
             preselectFirst: {
                 default: boolean('Preselect first', true),
-
             },
             preserveSearch: {
                 default: boolean('Preserve search', false),
@@ -451,10 +454,12 @@ storiesOf('Components.Select', module)
                         :internalSearch="internalSearch"
                         :label="label"
                         :limit="limit"
+                        :loading="loading"
                         :max="max"
                         :maxHeight="maxHeight"
                         :multiple="multiple"
                         :openDirection="openDirection"
+                        :options="options"
                         :optionsLimit="optionsLimit"
                         :optionLabel="optionLabel"
                         :optionKey="optionKey"

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -326,15 +326,10 @@ storiesOf('Components.Select', module)
     .add('Async data', () => ({
         data() {
             return {
-                loading: false,
-                options: [],
-                value: [1, 4, 7],
+                value: null,
             };
         },
         props: {
-            async: {
-                default: text('GET Request URL', 'https://jsonplaceholder.typicode.com/todos'),
-            },
             allowEmpty: {
                 default: boolean('Allow empty', true),
             },
@@ -369,7 +364,7 @@ storiesOf('Components.Select', module)
                 default: number('Max height', 500),
             },
             multiple: {
-                default: boolean('Multiple', true),
+                default: boolean('Multiple', false),
             },
             openDirection: {
                 default: select('Direction', {
@@ -395,10 +390,10 @@ storiesOf('Components.Select', module)
 
             },
             optionLabel: {
-                default: text('Property to display', 'title'),
+                default: text('Property to display', 'label'),
             },
             optionKey: {
-                default: text('Property to save', 'id'),
+                default: text('Property to save', 'value'),
             },
             resetAfter: {
                 default: boolean('Reset after', false),
@@ -419,7 +414,7 @@ storiesOf('Components.Select', module)
                 default: select('Tag position', {top: 'top', bottom: 'bottom'}, 'top'),
             },
             taggable: {
-                default: boolean('Taggable', true),
+                default: boolean('Taggable', false),
             },
         },
         methods: {
@@ -430,16 +425,14 @@ storiesOf('Components.Select', module)
             searchChange: action('searchChange'),
             select: action('select'),
             tag: action('tag'),
-        },
-        mounted() {
-            this.loading = true;
-            axios.get(this.async)
-                .then((response) => {
-                    setTimeout(() => {
-                        this.options = response.data;
-                        this.loading = false;
-                    }, 2000);
-                });
+            async asyncFind(search = '') {
+                await axios.get(`https://www.thecocktaildb.com/api/json/v1/1/search.php?s=${search}&limit=1`)
+                await new Promise(res => setTimeout(res, 1000));
+                return ['John', 'Adam', 'Sarah'];
+            },
+            asyncGetInitValue() {
+                return [];
+            }
         },
         template: `
             <div class="storybook-center">
@@ -447,6 +440,8 @@ storiesOf('Components.Select', module)
                     <p>Selected: {{ value }}</p>
                     <r-select
                         v-model="value"
+                        :asyncFind="asyncFind"
+                        :asyncGetInitValue="asyncGetInitValue"
                         :allowEmpty="allowEmpty"
                         :clearOnSelect="clearOnSelect"
                         :closeOnSelect="closeOnSelect"
@@ -456,12 +451,10 @@ storiesOf('Components.Select', module)
                         :internalSearch="internalSearch"
                         :label="label"
                         :limit="limit"
-                        :loading="loading"
                         :max="max"
                         :maxHeight="maxHeight"
                         :multiple="multiple"
                         :openDirection="openDirection"
-                        :options="options"
                         :optionsLimit="optionsLimit"
                         :optionLabel="optionLabel"
                         :optionKey="optionKey"

--- a/packages/recomponents/src/components/r-select/r-select.story.js
+++ b/packages/recomponents/src/components/r-select/r-select.story.js
@@ -426,13 +426,13 @@ storiesOf('Components.Select', module)
             select: action('select'),
             tag: action('tag'),
             async asyncFind(search = '') {
-                await axios.get(`https://www.thecocktaildb.com/api/json/v1/1/search.php?s=${search}&limit=1`)
+                await axios.get(`https://www.thecocktaildb.com/api/json/v1/1/search.php?s=${search}&limit=1`);
                 await new Promise(res => setTimeout(res, 1000));
                 return ['John', 'Adam', 'Sarah'];
             },
             asyncGetInitValue() {
                 return [];
-            }
+            },
         },
         template: `
             <div class="storybook-center">

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -575,7 +575,7 @@
                     this.$refs.search.setAttribute('aria-activedescendant', `${this.id}-${this.pointer.toString()}`);
                 }
             },
-            search() {
+            async search() {
                 /**
                  * Search text change
                  * @type {Event}
@@ -583,7 +583,7 @@
                 this.$emit('search-change', this.search, this.id);
 
                 if (this.computedIsAsync) {
-                    this.handleAsyncFind(this.search);
+                    await this.handleAsyncFind(this.search);
                 }
             },
             loading() {

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -36,7 +36,7 @@
                     <div class="r-select-tags-wrap"
                          v-show="visibleValues.length > 0"
                          @mousedown.prevent>
-                        <template v-for="(option, index) of computedValue"
+                        <template v-for="option of computedValue"
                                   @mousedown.prevent>
                             <!-- @slot Override default tag component -->
                             <slot name="tag"
@@ -172,7 +172,7 @@
                             </span>
                         </li>
                         <li class="r-select-content-element"
-                            v-show="showNoResults && (filteredOptions.length === 0 && search && !loading)">
+                            v-show="showNoResults && (filteredOptions.length === 0 && search && !loading && !computedIsLoading)">
                             <span class="r-select-content-element-option">
                                 <!-- @slot Override default no result component -->
                                 <slot name="noResult"
@@ -181,7 +181,7 @@
                             </span>
                         </li>
                         <li class="r-select-content-element"
-                            v-show="showNoOptions && (computedOptions.length === 0 && !search && !loading)">
+                            v-show="showNoOptions && (computedOptions.length === 0 && !search && !loading && !computedIsLoading)">
                             <span class="r-select-content-element-option">
                                 <!-- @slot Override default no options component -->
                                 <slot name="noOptions">{{messages['noOptions']}}</slot>
@@ -581,6 +581,10 @@
                  * @type {Event}
                  */
                 this.$emit('search-change', this.search, this.id);
+
+                if (this.computedIsAsync) {
+                    this.handleAsyncFind(this.search);
+                }
             },
             loading() {
                 this.preselect();


### PR DESCRIPTION
### What was a problem?
`r-select` didn't call the provided `asyncFind` method.

### How this PR fixes the problem?
Call `asyncFind` on `search` watcher.

### Check lists

- [x] Storybook updated
- [x] Added tests for async search
