### PR TITLE
fix(r-select): Update autocomplete attribute

### DIFF
--- a/packages/recomponents/src/components/r-select/r-select.spec.js
+++ b/packages/recomponents/src/components/r-select/r-select.spec.js
@@ -82,6 +82,19 @@ describe('r-select.vue', () => {
         expect(wrapper.findAll('.r-select-tag').at(1)).not.toEqual(undefined);
     });
 
+    it('should change autocomplete value', () => {
+        const wrapper = shallowMount(RSelect, {
+            propsData: {
+                autocomplete: 'none',
+                value: ['1', '2'],
+                options: ['1', '2', '3'],
+                multiple: true,
+            },
+        });
+        const autocomplete = wrapper.find('input.r-select-input').attributes('autocomplete');
+        expect(autocomplete).toEqual('none');
+    });
+
     it('should preselect passed simple value', () => {
         const wrapper = shallowMount(RSelect, {
             propsData: {

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -78,7 +78,7 @@
                        :name="name"
                        :id="id"
                        type="text"
-                       autocomplete="off"
+                       :autocomplete="autocomplete"
                        spellcheck="false"
                        :placeholder="placeholder"
                        :style="inputStyle"
@@ -288,6 +288,13 @@
             allowEmpty: {
                 type: Boolean,
                 default: true,
+            },
+            /**
+             * Specify autocomplete value
+             */
+            autocomplete: {
+                type: String,
+                default: 'off',
             },
             /**
              * List of keys where default behaviour will be ignored


### PR DESCRIPTION
### What was the problem?

Setting the `autocomplete` attribute of the input to `off` doesn't work on Chrome, making it show the autocomplete dropdown.

<img width="340" alt="Screen Shot 2021-01-13 at 12 57 59 PM" src="https://user-images.githubusercontent.com/1580169/104505371-c3f33380-55b1-11eb-809f-f38965ea708b.png">

### How this PR fixes the problem?

By adding autocomplete as a prop we can pass any value to it, e.g. 'none' and avoid the dropdown to be shown

### Check lists

- [x] Added tests for both browser and SSR render and for all components properties
- [x] Added story with all knobs and actions