### PR TITLE
Pick the start of the day for single date type input

### DIFF
--- a/packages/recomponents/src/components/r-date-input/r-date-input.vue
+++ b/packages/recomponents/src/components/r-date-input/r-date-input.vue
@@ -173,6 +173,8 @@
                         start: moment(date.start).tz(this.timezone).startOf('day'),
                         end: moment(date.end).tz(this.timezone).endOf('day'),
                     };
+                } else if (this.type === DateInputType.date) {
+                    value = moment(date).tz(this.timezone).startOf('day');
                 } else {
                     value = moment(date).tz(this.timezone);
                 }


### PR DESCRIPTION
### What was a problem?

It picks the current date with the current time, we should pick the start of the day for single date type of the `r-date-input` picker. 
