### PR TITLE
Set placement of the calendar popover to always bottom

### DIFF
--- a/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
+++ b/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
@@ -12,6 +12,7 @@
                      :mode="mode"
                      popover-visibility="focus"
                      :popover-content-offset="4"
+                     :popover="popoverConfigs"
                      :min-date="minDate"
                      :max-date="maxDate"
                      :columns="columns"
@@ -40,6 +41,7 @@
                      :select-attribute="dragSelectAttributes"
                      :drag-attribute="dragSelectAttributes"
                      color="blue"
+                     :popover="popoverConfigs"
                      :timezone="timezone"
                      :available-dates="availableDates"
                      :disabled-attribute="disabledAttribute"
@@ -149,6 +151,18 @@
                 initialDate: this.value,
                 masks: {
                     input: 'YYYY-MM-DD h:mm A',
+                },
+                popoverConfigs: {
+                    placement: 'bottom',
+                    modifiers: [
+                        {
+                            name: 'flip',
+                            options: {
+                                allowedAutoPlacements: ['bottom'],
+                                fallbackPlacements: ['bottom'],
+                            },
+                        },
+                    ],
                 },
                 themeStyles: {
                     wrapper: {


### PR DESCRIPTION
### What was a problem?

Previous version of the `r-date-input` was created with a `bottom` placement approach.
Now the fallback position sometimes uses `top` placement which is not supported by the projects where it is used.

### How this PR fixes the problem?

Set the `bottom` placement as a default and as a only allowed and fallback placements.
