### PR TITLE
fix(r-date-input): timezone for simple date

### DIFF
--- a/packages/recomponents/src/components/r-date-input/r-date-input.vue
+++ b/packages/recomponents/src/components/r-date-input/r-date-input.vue
@@ -176,7 +176,7 @@
                         end: moment(date.end).tz(this.timezone),
                     };
                 } else {
-                    value = moment(date).tz(this.timezone);
+                    value = moment(date).tz(this.timezone, this.type === DateInputType.date);
                 }
                 /**
                  * Date change by element click or from parent component


### PR DESCRIPTION
### What was a problem?

When the user picks a simple date (no range and time), it was converting the date not correctly.
