### PR TITLE
fix(r-select): keep the object value for selected

### DIFF
--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -258,6 +258,7 @@
         name: 'r-select',
         data() {
             return {
+                valueObject: null,
                 isOpen: false,
                 optimizedHeight: this.maxHeight,
                 pointer: 0,
@@ -646,7 +647,7 @@
                     .find(option => this.getOptionValue(option) === this.internalValue[0]);
 
                 const value = this.internalValue && this.internalValue.length
-                    ? this.getOptionLabel(activeOption)
+                    ? this.getOptionLabel(activeOption || this.valueObject)
                     : placeholder;
                 return this.multiple ? placeholder : value;
             },
@@ -706,7 +707,8 @@
                 const hasOptions = !!this.value
                     && (this.computedOptions
                         .find(opt => opt === this.value || opt[this.computedTrackBy] === this.value)
-                    || this.taggable);
+                    || this.taggable
+                    || this.computedIsAsync);
                 const value = Array.isArray(this.value)
                     ? this.value
                     : ((hasOptions && [this.value]) || []);
@@ -1042,6 +1044,7 @@
                     if (this.multiple) {
                         this.$emit('input', this.primitiveValue.concat([this.getOptionValue(option)]), this.id);
                     } else {
+                        this.valueObject = option;
                         this.$emit('input', this.getOptionValue(option), this.id);
                     }
 


### PR DESCRIPTION
### What was a problem?

Steps to reproduce: 
1. Use an `r-select` component with async search and enough options for several pages 
2. Use the search and select the value from not the first page

Expected behaviour: input shows the selected value
Actual behaviour: in a couple of seconds the value disappears.

### How this PR fixes the problem?

Keeping the object of selected value
