### PR TITLE
fix: migrate from shortid to nanoid

### DIFF
--- a/packages/recomponents/package.json
+++ b/packages/recomponents/package.json
@@ -54,7 +54,7 @@
     "lowlight": "^1.13.1",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.23",
-    "shortid": "^2.2.14",
+    "nanoid": "^3.1.25",
     "v-calendar": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
+++ b/packages/recomponents/src/components/r-checkbox/r-checkbox.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-    import shortId from 'shortid';
+    import {nanoid} from 'nanoid';
     import RIcon from '../r-icon/r-icon.vue';
 
     // TODO: prefixes of simple classes `r-is-error, r-is-disabled`
@@ -43,7 +43,7 @@
              */
             id: {
                 type: String,
-                default: () => shortId.generate(),
+                default: () => nanoid(),
             },
             /**
              * TBD

--- a/packages/recomponents/src/components/r-date-input/r-date-input.vue
+++ b/packages/recomponents/src/components/r-date-input/r-date-input.vue
@@ -23,7 +23,7 @@
 
 <script>
     import moment from 'moment';
-    import shortid from 'shortid';
+    import {nanoid} from 'nanoid';
     import rIcon from '../r-icon/r-icon.vue';
     import rSelect from '../r-select/r-select.vue';
     import {DateInputType, CalendarOptions} from './shared';
@@ -100,7 +100,7 @@
              */
             name: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * Used to specify what dates are selected

--- a/packages/recomponents/src/components/r-input/r-input.vue
+++ b/packages/recomponents/src/components/r-input/r-input.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script>
-    import shortid from 'shortid';
+    import {nanoid} from 'nanoid';
     import rIcon from '../r-icon/r-icon.vue';
     import '../../directives/r-fs-block';
     // TODO classes prefix r-is-error, r-no-flex, etc.
@@ -256,7 +256,7 @@
              */
             name: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * TBD

--- a/packages/recomponents/src/components/r-popper/r-popper.vue
+++ b/packages/recomponents/src/components/r-popper/r-popper.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-    import shortId from 'shortid';
+    import {nanoid} from 'nanoid';
     import '../../directives/r-click-outside/r-click-outside';
 
     const directions = {
@@ -181,7 +181,7 @@
         },
         data() {
             return {
-                id: shortId.generate(),
+                id: nanoid(),
                 hideTimer: null,
                 hideDelayMs: 200,
                 isPopperVisible: false,

--- a/packages/recomponents/src/components/r-radio/r-radio.vue
+++ b/packages/recomponents/src/components/r-radio/r-radio.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-    import shortid from 'shortid';
+    import {nanoid} from 'nanoid';
     import rIcon from '../r-icon/r-icon.vue';
 
     export default {
@@ -50,14 +50,14 @@
              */
             id: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * TBD
              */
             name: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * TBD

--- a/packages/recomponents/src/components/r-select/r-select.vue
+++ b/packages/recomponents/src/components/r-select/r-select.vue
@@ -212,7 +212,7 @@
 </template>
 
 <script>
-    import shortid from 'shortid';
+    import {nanoid} from 'nanoid';
     import AsyncInputMixin from '../../mixins/async-input-mixin';
     import RIcon from '../r-icon/r-icon.vue';
     import RBadge from '../r-badge/r-badge.vue';
@@ -365,7 +365,7 @@
              */
             id: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * Specify is the internal search enabled

--- a/packages/recomponents/src/components/r-tabs/r-tab.vue
+++ b/packages/recomponents/src/components/r-tabs/r-tab.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-    import shortId from 'shortid';
+    import {nanoid} from 'nanoid';
 
     export default {
         name: 'r-tab',
@@ -40,7 +40,7 @@
         },
         computed: {
             accessibilityId() {
-                return this.panelId || shortId.generate();
+                return this.panelId || nanoid();
             },
             tabPanelId() {
                 return `tabpanel-${this.accessibilityId}`;

--- a/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
+++ b/packages/recomponents/src/components/r-tabs/r-tabs.spec.js
@@ -218,9 +218,9 @@ describe('r-tabs.vue', () => {
         const tab = wrapper.findAll('.r-tab-item-link').at(0);
         const tabPanel = wrapper.find('.r-tab-content > div');
 
-        const generatedShortId = tab.attributes('id').replace('tab-', '');
-        const tabA11yId = `tab-${generatedShortId}`;
-        const tabPanelA11yId = `tabpanel-${generatedShortId}`;
+        const generatedNanoId = tab.attributes('id').replace('tab-', '');
+        const tabA11yId = `tab-${generatedNanoId}`;
+        const tabPanelA11yId = `tabpanel-${generatedNanoId}`;
 
         expect(tab.attributes('id')).toBe(tabA11yId);
         expect(tab.attributes('aria-controls')).toBe(tabPanelA11yId);

--- a/packages/recomponents/src/components/r-toggle/r-toggle.vue
+++ b/packages/recomponents/src/components/r-toggle/r-toggle.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-    import shortid from 'shortid';
+    import {nanoid} from 'nanoid';
 
     export default {
         name: 'RToggle',
@@ -37,7 +37,7 @@
              */
             name: {
                 type: String,
-                default: () => shortid.generate(),
+                default: () => nanoid(),
             },
             /**
              * Actual the actual model for the component

--- a/yarn.lock
+++ b/yarn.lock
@@ -6236,15 +6236,15 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@4.7.0, browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.5, browserslist@^4.6.4, browserslist@^4.8.5:
-  version "4.16.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.7.tgz#108b0d1ef33c4af1b587c54f390e7041178e4335"
-  integrity sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.0.tgz#1fcd81ec75b41d6d4994fb0831b92ac18c01649c"
+  integrity sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==
   dependencies:
-    caniuse-lite "^1.0.30001248"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.793"
+    caniuse-lite "^1.0.30001254"
+    colorette "^1.3.0"
+    electron-to-chromium "^1.3.830"
     escalade "^3.1.1"
-    node-releases "^1.1.73"
+    node-releases "^1.1.75"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -6614,10 +6614,10 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001036, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz#40615a3c416a047c5a4d45673e5257bf128eb3b5"
   integrity sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==
 
-caniuse-lite@^1.0.30001248:
-  version "1.0.30001249"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz#90a330057f8ff75bfe97a94d047d5e14fabb2ee8"
-  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
+caniuse-lite@^1.0.30001254:
+  version "1.0.30001257"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
+  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7242,10 +7242,10 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+colorette@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
 colors@1.0.3:
   version "1.0.3"
@@ -8848,10 +8848,10 @@ ejs@^2.6.1, ejs@^2.7.1, ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.793:
-  version "1.3.800"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.800.tgz#8efbb11e88b0a072d5c0250e6249123d3a76cb9a"
-  integrity sha512-qagikPjZJSDWP85uWoxs32oK/xk/y3MhDZELfKRCWI7pBc0ZFlmjnXb+3+aNMaiqboeDJJa0v7CJd5cO1HKwEQ==
+electron-to-chromium@^1.3.830:
+  version "1.3.836"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz#823cb9c98f28c64c673920f1c90ea3826596eaf9"
+  integrity sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -15541,6 +15541,11 @@ nanoid@^2.1.0:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
+nanoid@^3.1.25:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
+  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -15789,10 +15794,10 @@ node-object-hash@^1.2.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.2.tgz#385833d85b229902b75826224f6077be969a9e94"
   integrity sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ==
 
-node-releases@^1.1.73:
-  version "1.1.73"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
-  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+node-releases@^1.1.75:
+  version "1.1.75"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
+  integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
 
 node-res@^5.0.1:
   version "5.0.1"
@@ -21396,9 +21401,9 @@ tar-stream@^1.5.2:
     xtend "^4.0.0"
 
 tar@^2.0.0, tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.7.tgz#c566d1107d38b09e92983a68db5534fc7f6cab42"
-  integrity sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -23462,9 +23467,9 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^5.2.0, ws@^6.0.0, ws@^6.1.0, ws@^6.2.1, ws@^7.0.0, ws@^7.4.6:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
-  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
+  integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
 x-is-string@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Shortid is deprecated and is a security threat. Replace it with Nanoid.

fix #272

### What was a problem?

The shortid package is now deprecated.

### How this PR fixes the problem?

Replace shortid with nanoid.
