### PR TITLE
fix(r-date-input): fix the input event prop for date only type

### DIFF
--- a/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
+++ b/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
@@ -128,6 +128,10 @@
             timezone: {
                 type: String,
             },
+            hideOnSelection: {
+                type: Boolean,
+                default: false,
+            },
             /**
              * Define if the time format is 24H
              */
@@ -257,7 +261,10 @@
                     return;
                 }
                 this.$emit('input', date);
-                this.$refs.datePicker.hidePopover();
+
+                if (this.hideOnSelection) {
+                    this.$refs.datePicker.hidePopover();
+                }
             },
         },
     };

--- a/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
+++ b/packages/recomponents/src/components/r-date-input/r-calendar-manager.vue
@@ -5,7 +5,8 @@
         right-icon="calendar"
         v-show="disabled"/>
     <no-ssr>
-      <v-date-picker v-if="!isDateRange"
+      <v-date-picker ref="datePicker"
+                     v-if="!isDateRange"
                      v-show="!disabled"
                      :value="value"
                      @input="dateInput"
@@ -256,6 +257,7 @@
                     return;
                 }
                 this.$emit('input', date);
+                this.$refs.datePicker.hidePopover();
             },
         },
     };

--- a/packages/recomponents/src/components/r-date-input/r-date-input.vue
+++ b/packages/recomponents/src/components/r-date-input/r-date-input.vue
@@ -15,6 +15,7 @@
                           :placeholder="placeholder"
                           :available-dates="availableDates"
                           :is24hr="is24hr"
+                          :hide-on-selection="hideOnSelection"
                           @input="onInput"/>
       <span class="r-field-caption" v-if="helpText">{{ helpText }}</span>
     </div>
@@ -154,6 +155,13 @@
             is24hr: {
                 type: Boolean,
                 default: true,
+            },
+            /**
+             * Hide the popover once the date is selected
+            */
+            hideOnSelection: {
+                type: Boolean,
+                default: false,
             },
         },
         data() {

--- a/packages/recomponents/src/components/r-date-input/r-date-input.vue
+++ b/packages/recomponents/src/components/r-date-input/r-date-input.vue
@@ -193,8 +193,10 @@
                         start: moment(date.start).utc().tz(this.timezone, true),
                         end: moment(date.end).utc().tz(this.timezone, true),
                     };
+                } else if (this.type === DateInputType.date) {
+                    value = date;
                 } else {
-                    value = moment(date).utc().tz(this.timezone, true); /* this.type === DateInputType.date */
+                    value = moment(date).utc().tz(this.timezone, true);
                 }
                 /**
                  * Date change by element click or from parent component


### PR DESCRIPTION
### What was a problem?

For `type` of Date Input it should `@input` with the date only, without any time and timezone markers.

### How this PR fixes the problem?

Now it looks like `@input('2022-01-01')`
