### PR TITLE
fix(r-avatar): remove extra margin for .r-avatar-main

### DIFF
--- a/packages/recomponents/src/components/r-avatar/r-avatar.scss
+++ b/packages/recomponents/src/components/r-avatar/r-avatar.scss
@@ -36,10 +36,6 @@
     }
 }
 
-.r-avatar.r-avatar-description > .r-avatar-main {
-    margin-right: var(--avatar-margin-right);
-}
-
 .r-avatar-info * {
     margin: 0;
     line-height: var(--avatar-font-line-height);


### PR DESCRIPTION
### What was a problem?

Issue #315 

### How this PR fixes the problem?

Checked the usages of `r-avatar` component. 
Removed the extra space for `.r-avatar-main` class
