### PR TITLE
chore: Simplify r-click-outside directive to work in compat mode

### DIFF
--- a/packages/recomponents/src/directives/r-click-outside/r-click-outside.js
+++ b/packages/recomponents/src/directives/r-click-outside/r-click-outside.js
@@ -2,16 +2,16 @@
  * Simple directive to add click-outside detection to a component
  */
 export default {
-    bind(element, binding, vNode) {
-        element.vClickOutside = (event) => {
+    bind(element, {value}) {
+        element.clickOutside = (event) => {
             if (!element.contains(event.target)) {
-                vNode.context[binding.expression](event);
+                value(event);
             }
         };
-        window.document.addEventListener('mousedown', element.vClickOutside, true);
+        window.document.addEventListener('mousedown', element.clickOutside, true);
     },
     unbind(element) {
-        window.document.removeEventListener('mousedown', element.vClickOutside);
-        element.vClickOutside = null;
+        window.document.removeEventListener('mousedown', element.clickOutside);
+        element.clickOutside = null;
     },
 };


### PR DESCRIPTION
The` r-click-outside` directive is failing when using `recomponents` with `@vue/compat` mode with the following error:

![click-outside-error](https://user-images.githubusercontent.com/1316240/171122671-c8cd5653-fa08-4b59-85c8-31d2c3a9d7b4.png)

This PR simplifies the implementation to avoid using low level vNode API details like `vNode.context`. That way, it should work in compat mode. 

