### PR TITLE
fix: vue 3 app compat

### DIFF
--- a/packages/recomponents/src/components/r-pagination/r-pagination.vue
+++ b/packages/recomponents/src/components/r-pagination/r-pagination.vue
@@ -8,13 +8,11 @@
 </template>
 
 <script>
-    import Vue from 'vue';
     import PaginationControl from '../r-pagination-control/r-pagination-control.vue';
-
-    Vue.component('r-pagination-control', PaginationControl);
 
     export default {
         name: 'r-pagination',
+        components: {'r-pagination-control': PaginationControl},
         props: {
             /**
              * Wrapper for async pagination data provider

--- a/packages/recomponents/src/index.js
+++ b/packages/recomponents/src/index.js
@@ -28,7 +28,13 @@ function install(Vue, options = {}) {
         ErrorHandler,
         allowClose: allowToastCloseButton,
     });
-    Vue.component('v-date-picker', vDatePicker);
+
+    try {
+        Vue.component('v-date-picker', vDatePicker);
+    } catch (error) {
+        // Ignore errors when using Recomponents from @vue/compat mode
+    }
+
     Vue.component('no-ssr', NoSSR);
 
     /**


### PR DESCRIPTION
Our plan to migrate workbench and recomm to vue3 involves using `@vue/app` compat mode with `recomponents` original + `recomponents-next`. 

We need some adjustments for tests to be working in that mode.