### PR TITLE
chore: Add show prop to make modals compatible with incoming vue3 ver…

### DIFF
--- a/packages/recomponents/src/components/r-modal/r-modal.story.js
+++ b/packages/recomponents/src/components/r-modal/r-modal.story.js
@@ -13,6 +13,9 @@ storiesOf('Components.Modal', module)
             };
         },
         props: {
+            show: {
+                default: boolean('Show modal', true),
+            },
             title: {
                 default: text('Title', 'Modal'),
             },
@@ -47,7 +50,7 @@ storiesOf('Components.Modal', module)
         template: `
             <div class="storybook-center">
                 <r-button @click="isModalOpen = true;">Open</r-button>
-                <r-modal v-if="isModalOpen"
+                <r-modal :show="isModalOpen"
                         :title="title"
                         :cancelLabel="cancelLabel"
                         :size="size"

--- a/packages/recomponents/src/components/r-modal/r-modal.vue
+++ b/packages/recomponents/src/components/r-modal/r-modal.vue
@@ -1,6 +1,7 @@
 <template>
     <transition name="r-modal" @appear="appear" @enter="enter" @leave="leave">
-        <div @mousedown="close"
+        <div v-if="show"
+            @mousedown="close"
              tabindex="0"
              ref="container"
              @keyup.esc="close"
@@ -77,6 +78,13 @@
             RIconButton,
         },
         props: {
+            /**
+            * Use this prop to conditionally show the modal from the outside
+            */
+            show: {
+                type: Boolean,
+                default: true,
+            },
             /**
              * TBD
              */


### PR DESCRIPTION
Vue3 transitions introduced [this breaking change](https://v3-migration.vuejs.org/breaking-changes/transition.html) affecting modals. 

The solution is adding a `show` boolean prop like we did in [recomponents-next modals](https://musical-happiness-cd7b76de.pages.github.io/components/modal.html).

Adding the same prop to recomponents (vue 2) will enable us to migrate all recomm modals in main branch instead of being force to do it in app-compat branch ([check this RFC ](https://github.com/Rebilly/docs-product/pull/1177)for more context).