### PR TITLE
feat: Remove SSR step from github actions

### DIFF
--- a/.github/workflows/recomponents.yml
+++ b/.github/workflows/recomponents.yml
@@ -96,36 +96,6 @@ jobs:
     - name: Run snapshot tests
       run: |
         docker-compose -f ./packages/recomponents/.image-snapshots/docker-compose.yml up --build
-  ssr:
-    name: Verify SSR
-    runs-on: ubuntu-latest
-    needs: [compile]
-    strategy:
-      matrix:
-        node-version: [12.x]
-    env:
-      NODE_ENV: test
-    steps:
-    - name: Checkout
-      uses: actions/checkout@main
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies
-      run: |
-        yarn
-    - name: Download Recomponents build
-      uses: actions/download-artifact@main
-      with:
-        name: Recomponents
-        path: ./
-    - name: Uncompress Recomponents build
-      run: |
-        unzip -o recomponents.zip -d packages/nuxt/node_modules/@rebilly/recomponents/dist
-    - name: Build Nuxt application
-      run: |
-        yarn workspace recomponents-demo-nuxt build
   release:
     name: Semantic release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nobody is using recomponents from SSR clients like nuxt so removing this step from GHA will make CI runs faster. 