### PR TITLE
feat: Actually build minified version

### DIFF
--- a/.github/workflows/recomponents.yml
+++ b/.github/workflows/recomponents.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-    env:
-      NODE_ENV: test
     steps:
     - name: Checkout
       uses: actions/checkout@main


### PR DESCRIPTION
Currently the CI pipeline sets the `NODE_ENV` to `test`, which means our build is not minified.

You can test this locally like: `NODE_ENV=test yarn build`

And you will see:
```
  File                            Size                  Gzipped

  dist/recomponents.umd.min.js    1830.44 KiB           255.06 KiB
  dist/recomponents.umd.js        1830.44 KiB           255.06 KiB
  dist/recomponents.common.js     1829.97 KiB           254.88 KiB
  dist/recomponents.css           148.43 KiB            20.24 KiB
```

Instead of:
```
  File                            Size                  Gzipped

  dist/recomponents.umd.min.js    680.43 KiB            170.08 KiB
  dist/recomponents.umd.js        1181.47 KiB           241.01 KiB
  dist/recomponents.common.js     1180.99 KiB           240.89 KiB
  dist/recomponents.css           114.87 KiB            17.48 KiB
```

You can also see this reflected in the [latest dist on unpkg, where the minified umd file is 1.9 megs](https://unpkg.com/browse/@rebilly/recomponents@1.39.0/dist/) 😨 